### PR TITLE
Add python32: Python 3.2.3

### DIFF
--- a/python32.rb
+++ b/python32.rb
@@ -1,0 +1,267 @@
+require 'formula'
+
+# Python3 is the new language standard, not just a new revision.
+# It's somewhat incompatible to Python 2.x, therefore, the executable
+# "python" will always point to the 2.x version which you can get by
+# `brew install python`.
+
+class Python32 < Formula
+  homepage 'http://www.python.org/'
+  url 'http://python.org/ftp/python/3.2.3/Python-3.2.3.tar.bz2'
+  sha1 '4c2d562a0681ba27bc920500050e2f08de224311'
+  VER='3.2'  # The <major>.<minor> is used so often.
+
+  option :universal
+  option 'quicktest', 'Run `make quicktest` after the build'
+  option 'with-brewed-openssl', "Use Homebrew's openSSL instead of the one from OS X"
+
+  resource 'setuptools' do
+    url 'https://pypi.python.org/packages/source/s/setuptools/setuptools-2.1.tar.gz'
+    sha1 '3e4a325d807eb0104e98985e7bd9f1ef86fc2efa'
+  end
+
+  resource 'pip' do
+    url 'https://pypi.python.org/packages/source/p/pip/pip-1.4.1.tar.gz'
+    sha1 '9766254c7909af6d04739b4a7732cc29e9a48cb0'
+  end
+
+  def site_packages_cellar
+    prefix/"Frameworks/Python.framework/Versions/#{VER}/lib/python#{VER}/site-packages"
+  end
+
+  # The HOMEBREW_PREFIX location of site-packages.
+  def site_packages
+    HOMEBREW_PREFIX/"lib/python#{VER}/site-packages"
+  end
+
+  # Where distribute/pip will install executable scripts.
+  def scripts_folder
+    HOMEBREW_PREFIX/"share/python3"
+  end
+
+  def effective_lib
+    prefix/"Frameworks/Python.framework/Versions/#{VER}/lib"
+  end
+
+  def install
+    # Unset these so that installing pip and distribute puts them where we want
+    # and not into some other Python the user has installed.
+    ENV['PYTHONPATH'] = nil
+    ENV['PYTHONHOME'] = nil
+
+    args = %W[--prefix=#{prefix}
+             --enable-ipv6
+             --datarootdir=#{share}
+             --datadir=#{share}
+             --enable-framework=#{prefix}/Frameworks
+           ]
+
+    args << '--without-gcc' if ENV.compiler == :clang
+
+    if build.universal?
+      ENV.universal_binary
+      args << "--enable-universalsdk" << "--with-universal-archs=intel"
+    end
+
+    distutils_fix_superenv(args)
+    distutils_fix_stdenv
+
+    # Python does not need all of X11, these bundled Headers are enough
+    ENV.append 'CPPFLAGS', "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers" unless MacOS::CLT.installed?
+
+    # Allow sqlite3 module to load extensions: http://docs.python.org/library/sqlite3.html#f1
+    inreplace "setup.py", 'sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))', 'pass'
+
+    system "./configure", *args
+
+    system "make"
+
+    ENV.deparallelize # Installs must be serialized
+    # Tell Python not to install into /Applications (default for framework builds)
+    system "make", "install", "PYTHONAPPSDIR=#{prefix}"
+    # Demos and Tools
+    (HOMEBREW_PREFIX/'share/python3').mkpath
+    system "make", "frameworkinstallextras", "PYTHONAPPSDIR=#{share}/python3"
+    system "make", "quicktest" if build.include? "quicktest"
+
+    # Any .app get a " 3" attached, so it does not conflict with python 2.x.
+    Dir.glob(prefix/"*.app").each do |app|
+      mv app, app.gsub(".app", " 3.app")
+    end
+
+    # Post-install, fix up the site-packages and install-scripts folders
+    # so that user-installed Python software survives minor updates, such
+    # as going from 3.3.0 to 3.3.1:
+
+    # Remove the site-packages that Python created in its Cellar.
+    site_packages_cellar.rmtree
+    # Create a site-packages in HOMEBREW_PREFIX/lib/python#{VER}/site-packages
+    site_packages.mkpath
+    # Symlink the prefix site-packages into the cellar.
+    ln_s site_packages, site_packages_cellar
+
+    # Teach python not to use things from /System
+    # and tell it about the correct site-package dir because we moved it
+    sitecustomize = site_packages_cellar/"sitecustomize.py"
+    rm sitecustomize if File.exist? sitecustomize
+    sitecustomize.write(sitecustomize_content)
+
+    # "python3" and executable is forgotten for framework builds.
+    # Make sure homebrew symlinks it to HOMEBREW_PREFIX/bin.
+    ln_s "#{bin}/python#{VER}", "#{bin}/python3" unless (bin/"python3").exist?
+
+    # Install distribute for python3 and assure there's no name clash
+    # with what the python (2.x) formula installs.
+    scripts_folder.mkpath
+    setup_args = ["-s", "setup.py", "install", "--force", "--verbose", "--install-lib=#{site_packages_cellar}", "--install-scripts=#{bin}" ]
+
+    resource('setuptools').stage { system "#{bin}/python3", *setup_args }
+    mv bin/'easy_install', bin/'easy_install3'
+
+    resource('pip').stage { system "#{bin}/python3", *setup_args }
+    mv bin/'pip', bin/'pip3'
+
+    # Tell distutils-based installers where to put scripts
+    (prefix/"Frameworks/Python.framework/Versions/#{VER}/lib/python#{VER}/distutils/distutils.cfg").write <<-EOF.undent
+      [install]
+      install-scripts=#{scripts_folder}
+      install-lib=#{site_packages}
+    EOF
+
+    unless MacOS::CLT.installed?
+      makefile = prefix/"Frameworks/Python.framework/Versions/#{VER}/lib/python#{VER}/config-#{VER}m/Makefile"
+      inreplace makefile do |s|
+        s.gsub!(/^CC=.*$/, "CC=xcrun clang")
+        s.gsub!(/^CXX=.*$/, "CXX=xcrun clang++")
+        s.gsub!(/^AR=.*$/, "AR=xcrun ar")
+        s.gsub!(/^RANLIB=.*$/, "RANLIB=xcrun ranlib")
+      end
+    end
+
+  end
+
+  def distutils_fix_superenv(args)
+    if superenv?
+      # To allow certain Python bindings to find brewed software:
+      cflags = "CFLAGS=-I#{HOMEBREW_PREFIX}/include"
+      ldflags = "LDFLAGS=-L#{HOMEBREW_PREFIX}/lib"
+      unless MacOS::CLT.installed?
+        # Help Python's build system (distribute/pip) to build things on Xcode-only systems
+        # The setup.py looks at "-isysroot" to get the sysroot (and not at --sysroot)
+        cflags += " -isysroot #{MacOS.sdk_path}"
+        ldflags += " -isysroot #{MacOS.sdk_path}"
+        # Same zlib.h-not-found-bug as in env :std (see below)
+        args << "CPPFLAGS=-I#{MacOS.sdk_path}/usr/include"
+      end
+      args << cflags
+      args << ldflags
+      # Avoid linking to libgcc http://code.activestate.com/lists/python-dev/112195/
+      args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
+      # We want our readline! This is just to outsmart the detection code,
+      # superenv makes cc always find includes/libs!
+      inreplace "setup.py",
+                "do_readline = self.compiler.find_library_file(lib_dirs, 'readline')",
+                "do_readline = '#{HOMEBREW_PREFIX}/opt/readline/lib/libhistory.dylib'"
+    end
+  end
+
+  def distutils_fix_stdenv()
+    if not superenv?
+      # Python scans all "-I" dirs but not "-isysroot", so we add
+      # the needed includes with "-I" here to avoid this err:
+      #     building dbm using ndbm
+      #     error: /usr/include/zlib.h: No such file or directory
+      ENV.append 'CPPFLAGS', "-I#{MacOS.sdk_path}/usr/include" unless MacOS::CLT.installed?
+
+      # Don't use optimizations other than "-Os" here, because Python's distutils
+      # remembers (hint: `python3-config --cflags`) and reuses them for C
+      # extensions which can break software (such as scipy 0.11 fails when
+      # "-msse4" is present.)
+      ENV.minimal_optimization
+
+      # We need to enable warnings because the configure.in uses -Werror to detect
+      # "whether gcc supports ParseTuple" (https://github.com/mxcl/homebrew/issues/12194)
+      ENV.enable_warnings
+      if ENV.compiler == :clang
+        # http://docs.python.org/devguide/setup.html#id8 suggests to disable some Warnings.
+        ENV.append_to_cflags '-Wno-unused-value'
+        ENV.append_to_cflags '-Wno-empty-body'
+        ENV.append_to_cflags '-Qunused-arguments'
+      end
+    end
+  end
+
+  def sitecustomize_content
+    <<-EOF.undent
+      # This file is created by `brew install python3` and is executed on each
+      # python#{VER} startup. Don't print from here, or else universe will collapse.
+      import sys
+      import site
+
+      # Only do fix 1 and 2, if the currently run python is a brewed one.
+      if sys.executable.startswith('#{HOMEBREW_PREFIX}'):
+          # Fix 1)
+          #   A setuptools.pth and/or easy-install.pth sitting either in
+          #   /Library/Python/2.7/site-packages or in
+          #   ~/Library/Python/2.7/site-packages can inject the
+          #   /System's Python site-packages. People then report
+          #   "OSError: [Errno 13] Permission denied" because pip/easy_install
+          #   attempts to install into
+          #   /System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python
+          #   See: https://github.com/mxcl/homebrew/issues/14712
+          sys.path = [ p for p in sys.path if not p.startswith('/System') ]
+
+          # Fix 2)
+          #   Remove brewed Python's hard-coded site-packages
+          sys.path.remove('#{site_packages_cellar}')
+
+      # Fix 3)
+      #   For all Pythons: Tell about homebrew's site-packages location.
+      #   This is needed for Python to parse *.pth files.
+      site.addsitedir('#{site_packages}')
+    EOF
+  end
+
+  def caveats
+    text = <<-EOS.undent
+      Homebrew's Python3 framework
+        #{prefix}/Frameworks/Python.framework
+
+      Distribute and Pip have been installed. To update them
+        pip3 install --upgrade distribute
+        pip3 install --upgrade pip
+
+      To symlink "Idle 3" and the "Python Launcher 3" to ~/Applications
+        `brew linkapps`
+
+      You can install Python packages with
+        `pip3 install <your_favorite_package>`
+
+      They will install into the site-package directory
+        #{site_packages}
+      Executable python scripts will be put in:
+        #{scripts_folder}
+      so you may want to put "#{scripts_folder}" in your PATH, too.
+
+      See: https://github.com/mxcl/homebrew/wiki/Homebrew-and-Python
+    EOS
+
+    # Tk warning only for 10.6
+    tk_caveats = <<-EOS.undent
+
+      Apple's Tcl/Tk is not recommended for use with Python on Mac OS X 10.6.
+      For more information see: http://www.python.org/download/mac/tcltk/
+    EOS
+
+    text += tk_caveats unless MacOS.version >= :lion
+    return text
+  end
+
+  def test
+    # Check if sqlite is ok, because we build with --enable-loadable-sqlite-extensions
+    # and it can occur that building sqlite silently fails if OSX's sqlite is used.
+    system "#{bin}/python#{VER}", "-c", "import sqlite3"
+    # Check if some other modules import. Then the linked libs are working.
+    system "#{bin}/python#{VER}", "-c", "import tkinter; root = tkinter.Tk()"
+  end
+end

--- a/python32.rb
+++ b/python32.rb
@@ -7,8 +7,8 @@ require 'formula'
 
 class Python32 < Formula
   homepage 'http://www.python.org/'
-  url 'http://python.org/ftp/python/3.2.3/Python-3.2.3.tar.bz2'
-  sha1 '4c2d562a0681ba27bc920500050e2f08de224311'
+  url 'https://www.python.org/ftp/python/3.2.5/Python-3.2.5.tar.bz2'
+  sha1 '6bd2714704995bc84fc9b8e3019205bf75d44969'
   VER='3.2'  # The <major>.<minor> is used so often.
 
   option :universal

--- a/python32.rb
+++ b/python32.rb
@@ -1,19 +1,17 @@
 require 'formula'
 
-# Python3 is the new language standard, not just a new revision.
-# It's somewhat incompatible to Python 2.x, therefore, the executable
-# "python" will always point to the 2.x version which you can get by
-# `brew install python`.
-
 class Python32 < Formula
-  homepage 'http://www.python.org/'
+  homepage 'https://www.python.org/'
   url 'https://www.python.org/ftp/python/3.2.5/Python-3.2.5.tar.bz2'
   sha1 '6bd2714704995bc84fc9b8e3019205bf75d44969'
   VER='3.2'  # The <major>.<minor> is used so often.
+  revision 1
+
+  head 'http://hg.python.org/cpython', :using => :hg, :branch => VER
 
   option :universal
   option 'quicktest', 'Run `make quicktest` after the build'
-  option 'with-brewed-openssl', "Use Homebrew's openSSL instead of the one from OS X"
+  option 'with-brewed-tk', "Use Homebrew's Tk (has optional Cocoa and threads support)"
 
   resource 'setuptools' do
     url 'https://pypi.python.org/packages/source/s/setuptools/setuptools-5.7.tar.gz'
@@ -25,6 +23,20 @@ class Python32 < Formula
     sha1 'e6cd9e6f2fd8d28c9976313632ef8aa8ac31249e'
   end
 
+  depends_on 'pkg-config' => :build
+  depends_on 'readline' => :recommended
+  depends_on 'sqlite' => :recommended
+  depends_on 'gdbm' => :recommended
+  depends_on 'openssl'
+  depends_on 'xz' => :recommended  # for the lzma module added in 3.3
+  depends_on 'homebrew/dupes/tcl-tk' if build.with? 'brewed-tk'
+  depends_on :x11 if build.with? "brewed-tk" and Tab.for_name("tcl-tk").with? "x11"
+
+  skip_clean "bin/pip3", "bin/pip-#{VER}"
+  skip_clean "bin/easy_install3", "bin/easy_install-#{VER}"
+
+  patch :DATA if build.with? 'brewed-tk'
+
   def site_packages_cellar
     prefix/"Frameworks/Python.framework/Versions/#{VER}/lib/python#{VER}/site-packages"
   end
@@ -34,43 +46,68 @@ class Python32 < Formula
     HOMEBREW_PREFIX/"lib/python#{VER}/site-packages"
   end
 
-  # Where distribute/pip will install executable scripts.
-  def scripts_folder
-    HOMEBREW_PREFIX/"share/python3"
+  fails_with :llvm do
+    build 2336
+    cause <<-EOS.undent
+      Could not find platform dependent libraries <exec_prefix>
+      Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
+      python.exe(14122) malloc: *** mmap(size=7310873954244194304) failed (error code=12)
+      *** error: can't allocate region
+      *** set a breakpoint in malloc_error_break to debug
+      Could not import runpy module
+      make: *** [pybuilddir.txt] Segmentation fault: 11
+    EOS
   end
 
-  def effective_lib
-    prefix/"Frameworks/Python.framework/Versions/#{VER}/lib"
+  # setuptools remembers the build flags python is built with and uses them to
+  # build packages later. Xcode-only systems need different flags.
+  def pour_bottle?
+    MacOS::CLT.installed?
   end
 
   def install
-    # Unset these so that installing pip and distribute puts them where we want
+    # Unset these so that installing pip and setuptools puts them where we want
     # and not into some other Python the user has installed.
-    ENV['PYTHONPATH'] = nil
     ENV['PYTHONHOME'] = nil
+    ENV['PYTHONPATH'] = nil
 
-    args = %W[--prefix=#{prefix}
-             --enable-ipv6
-             --datarootdir=#{share}
-             --datadir=#{share}
-             --enable-framework=#{prefix}/Frameworks
-           ]
+    args = %W[
+      --prefix=#{prefix}
+      --enable-ipv6
+      --datarootdir=#{share}
+      --datadir=#{share}
+      --enable-framework=#{frameworks}
+    ]
 
     args << '--without-gcc' if ENV.compiler == :clang
+
+    if superenv?
+      distutils_fix_superenv(args)
+    else
+      distutils_fix_stdenv
+    end
 
     if build.universal?
       ENV.universal_binary
       args << "--enable-universalsdk" << "--with-universal-archs=intel"
     end
 
-    distutils_fix_superenv(args)
-    distutils_fix_stdenv
-
-    # Python does not need all of X11, these bundled Headers are enough
-    ENV.append 'CPPFLAGS', "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers" unless MacOS::CLT.installed?
-
     # Allow sqlite3 module to load extensions: http://docs.python.org/library/sqlite3.html#f1
-    inreplace "setup.py", 'sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))', 'pass'
+    inreplace("setup.py", 'sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))', 'pass') if build.with? 'sqlite'
+
+    # Allow python modules to use ctypes.find_library to find homebrew's stuff
+    # even if homebrew is not a /usr/local/lib. Try this with:
+    # `brew install enchant && pip install pyenchant`
+    inreplace "./Lib/ctypes/macholib/dyld.py" do |f|
+      f.gsub! 'DEFAULT_LIBRARY_FALLBACK = [', "DEFAULT_LIBRARY_FALLBACK = [ '#{HOMEBREW_PREFIX}/lib',"
+      f.gsub! 'DEFAULT_FRAMEWORK_FALLBACK = [', "DEFAULT_FRAMEWORK_FALLBACK = [ '#{HOMEBREW_PREFIX}/Frameworks',"
+    end
+
+    if build.with? 'brewed-tk'
+      tcl_tk = Formula["tcl-tk"].opt_prefix
+      ENV.append 'CPPFLAGS', "-I#{tcl_tk}/include"
+      ENV.append 'LDFLAGS', "-L#{tcl_tk}/lib"
+    end
 
     system "./configure", *args
 
@@ -80,170 +117,180 @@ class Python32 < Formula
     # Tell Python not to install into /Applications (default for framework builds)
     system "make", "install", "PYTHONAPPSDIR=#{prefix}"
     # Demos and Tools
-    (HOMEBREW_PREFIX/'share/python3').mkpath
     system "make", "frameworkinstallextras", "PYTHONAPPSDIR=#{share}/python3"
     system "make", "quicktest" if build.include? "quicktest"
 
     # Any .app get a " 3" attached, so it does not conflict with python 2.x.
-    Dir.glob(prefix/"*.app").each do |app|
-      mv app, app.gsub(".app", " 3.app")
-    end
+    Dir.glob("#{prefix}/*.app") { |app| mv app, app.sub(".app", " 3.app") }
 
-    # Post-install, fix up the site-packages and install-scripts folders
-    # so that user-installed Python software survives minor updates, such
-    # as going from 3.3.0 to 3.3.1:
+    # A fix, because python and python3 both want to install Python.framework
+    # and therefore we can't link both into HOMEBREW_PREFIX/Frameworks
+    # https://github.com/Homebrew/homebrew/issues/15943
+    ["Headers", "Python", "Resources"].each{ |f| rm(prefix/"Frameworks/Python.framework/#{f}") }
+    rm prefix/"Frameworks/Python.framework/Versions/Current"
 
     # Remove the site-packages that Python created in its Cellar.
     site_packages_cellar.rmtree
-    # Create a site-packages in HOMEBREW_PREFIX/lib/python#{VER}/site-packages
-    site_packages.mkpath
-    # Symlink the prefix site-packages into the cellar.
-    ln_s site_packages, site_packages_cellar
-
-    # Teach python not to use things from /System
-    # and tell it about the correct site-package dir because we moved it
-    sitecustomize = site_packages_cellar/"sitecustomize.py"
-    rm sitecustomize if File.exist? sitecustomize
-    sitecustomize.write(sitecustomize_content)
 
     # "python3" and executable is forgotten for framework builds.
     # Make sure homebrew symlinks it to HOMEBREW_PREFIX/bin.
     ln_s "#{bin}/python#{VER}", "#{bin}/python3" unless (bin/"python3").exist?
+  end
+
+  def post_install
+    # Fix up the site-packages so that user-installed Python software survives
+    # minor updates, such as going from 3.3.2 to 3.3.3:
+
+    # Create a site-packages in HOMEBREW_PREFIX/lib/python#{VER}/site-packages
+    site_packages.mkpath
+
+    # Symlink the prefix site-packages into the cellar.
+    site_packages_cellar.unlink if site_packages_cellar.exist?
+    site_packages_cellar.parent.install_symlink site_packages
+
+    # Write our sitecustomize.py
+    rm_rf Dir["#{site_packages}/sitecustomize.py[co]"]
+    (site_packages/"sitecustomize.py").atomic_write(sitecustomize)
+
+    # Remove old setuptools installations that may still fly around and be
+    # listed in the easy_install.pth. This can break setuptools build with
+    # zipimport.ZipImportError: bad local file header
+    # setuptools-0.9.8-py3.3.egg
+    rm_rf Dir["#{site_packages}/setuptools*"]
+    rm_rf Dir["#{site_packages}/distribute*"]
+
+    # And now we write the distutils.cfg
+    cfg = prefix/"Frameworks/Python.framework/Versions/#{VER}/lib/python#{VER}/distutils/distutils.cfg"
+    cfg.atomic_write <<-EOF.undent
+      [global]
+      verbose=1
+      [install]
+      prefix=#{HOMEBREW_PREFIX}
+    EOF
 
     # Install distribute for python3 and assure there's no name clash
     # with what the python (2.x) formula installs.
-    scripts_folder.mkpath
-    setup_args = ["-s", "setup.py", "install", "--force", "--verbose", "--install-lib=#{site_packages_cellar}", "--install-scripts=#{bin}" ]
 
+    setup_args = ["-s", "setup.py", "install", "--force", "--verbose", "--install-lib=#{site_packages_cellar}", "--install-scripts=#{bin}" ]
+ 
     resource('setuptools').stage { system "#{bin}/python3", *setup_args }
     mv bin/'easy_install', bin/'easy_install3'
 
     resource('pip').stage { system "#{bin}/python3", *setup_args }
     mv bin/'pip', bin/'pip3'
-
-    # Tell distutils-based installers where to put scripts
-    (prefix/"Frameworks/Python.framework/Versions/#{VER}/lib/python#{VER}/distutils/distutils.cfg").write <<-EOF.undent
-      [install]
-      install-scripts=#{scripts_folder}
-      install-lib=#{site_packages}
-    EOF
-
-    unless MacOS::CLT.installed?
-      makefile = prefix/"Frameworks/Python.framework/Versions/#{VER}/lib/python#{VER}/config-#{VER}m/Makefile"
-      inreplace makefile do |s|
-        s.gsub!(/^CC=.*$/, "CC=xcrun clang")
-        s.gsub!(/^CXX=.*$/, "CXX=xcrun clang++")
-        s.gsub!(/^AR=.*$/, "AR=xcrun ar")
-        s.gsub!(/^RANLIB=.*$/, "RANLIB=xcrun ranlib")
-      end
-    end
-
   end
 
   def distutils_fix_superenv(args)
-    if superenv?
-      # To allow certain Python bindings to find brewed software:
-      cflags = "CFLAGS=-I#{HOMEBREW_PREFIX}/include"
-      ldflags = "LDFLAGS=-L#{HOMEBREW_PREFIX}/lib"
-      unless MacOS::CLT.installed?
-        # Help Python's build system (distribute/pip) to build things on Xcode-only systems
-        # The setup.py looks at "-isysroot" to get the sysroot (and not at --sysroot)
-        cflags += " -isysroot #{MacOS.sdk_path}"
-        ldflags += " -isysroot #{MacOS.sdk_path}"
-        # Same zlib.h-not-found-bug as in env :std (see below)
-        args << "CPPFLAGS=-I#{MacOS.sdk_path}/usr/include"
+    # To allow certain Python bindings to find brewed software (and sqlite):
+    sqlite = Formula["sqlite"].opt_prefix
+    cflags = "CFLAGS=-I#{HOMEBREW_PREFIX}/include -I#{sqlite}/include"
+    ldflags = "LDFLAGS=-L#{HOMEBREW_PREFIX}/lib -L#{sqlite}/lib"
+    unless MacOS::CLT.installed?
+      # Help Python's build system (setuptools/pip) to build things on Xcode-only systems
+      # The setup.py looks at "-isysroot" to get the sysroot (and not at --sysroot)
+      cflags += " -isysroot #{MacOS.sdk_path}"
+      ldflags += " -isysroot #{MacOS.sdk_path}"
+      args << "CPPFLAGS=-I#{MacOS.sdk_path}/usr/include" # find zlib
+      if build.without? 'brewed-tk'
+        cflags += " -I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
       end
-      args << cflags
-      args << ldflags
-      # Avoid linking to libgcc http://code.activestate.com/lists/python-dev/112195/
-      args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
-      # We want our readline! This is just to outsmart the detection code,
-      # superenv makes cc always find includes/libs!
-      inreplace "setup.py",
-                "do_readline = self.compiler.find_library_file(lib_dirs, 'readline')",
-                "do_readline = '#{HOMEBREW_PREFIX}/opt/readline/lib/libhistory.dylib'"
+    end
+    args << cflags
+    args << ldflags
+    # Avoid linking to libgcc http://code.activestate.com/lists/python-dev/112195/
+    args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
+    # We want our readline! This is just to outsmart the detection code,
+    # superenv makes cc always find includes/libs!
+    inreplace "setup.py",
+              "do_readline = self.compiler.find_library_file(lib_dirs, 'readline')",
+              "do_readline = '#{HOMEBREW_PREFIX}/opt/readline/lib/libhistory.dylib'"
+  end
+
+  def distutils_fix_stdenv
+    # Python scans all "-I" dirs but not "-isysroot", so we add
+    # the needed includes with "-I" here to avoid this err:
+    #     building dbm using ndbm
+    #     error: /usr/include/zlib.h: No such file or directory
+    ENV.append 'CPPFLAGS', "-I#{MacOS.sdk_path}/usr/include" unless MacOS::CLT.installed?
+
+    # Don't use optimizations other than "-Os" here, because Python's distutils
+    # remembers (hint: `python3-config --cflags`) and reuses them for C
+    # extensions which can break software (such as scipy 0.11 fails when
+    # "-msse4" is present.)
+    ENV.minimal_optimization
+
+    # We need to enable warnings because the configure.in uses -Werror to detect
+    # "whether gcc supports ParseTuple" (https://github.com/Homebrew/homebrew/issues/12194)
+    ENV.enable_warnings
+    if ENV.compiler == :clang
+      # http://docs.python.org/devguide/setup.html#id8 suggests to disable some Warnings.
+      ENV.append_to_cflags '-Wno-unused-value'
+      ENV.append_to_cflags '-Wno-empty-body'
     end
   end
 
-  def distutils_fix_stdenv()
-    if not superenv?
-      # Python scans all "-I" dirs but not "-isysroot", so we add
-      # the needed includes with "-I" here to avoid this err:
-      #     building dbm using ndbm
-      #     error: /usr/include/zlib.h: No such file or directory
-      ENV.append 'CPPFLAGS', "-I#{MacOS.sdk_path}/usr/include" unless MacOS::CLT.installed?
-
-      # Don't use optimizations other than "-Os" here, because Python's distutils
-      # remembers (hint: `python3-config --cflags`) and reuses them for C
-      # extensions which can break software (such as scipy 0.11 fails when
-      # "-msse4" is present.)
-      ENV.minimal_optimization
-
-      # We need to enable warnings because the configure.in uses -Werror to detect
-      # "whether gcc supports ParseTuple" (https://github.com/mxcl/homebrew/issues/12194)
-      ENV.enable_warnings
-      if ENV.compiler == :clang
-        # http://docs.python.org/devguide/setup.html#id8 suggests to disable some Warnings.
-        ENV.append_to_cflags '-Wno-unused-value'
-        ENV.append_to_cflags '-Wno-empty-body'
-        ENV.append_to_cflags '-Qunused-arguments'
-      end
-    end
-  end
-
-  def sitecustomize_content
+  def sitecustomize
     <<-EOF.undent
-      # This file is created by `brew install python3` and is executed on each
-      # python#{VER} startup. Don't print from here, or else universe will collapse.
+      # This file is created by Homebrew and is executed on each python startup.
+      # Don't print from here, or else python command line scripts may fail!
+      # <https://github.com/Homebrew/homebrew/wiki/Homebrew-and-Python>
+      import os
       import sys
-      import site
 
-      # Only do fix 1 and 2, if the currently run python is a brewed one.
-      if sys.executable.startswith('#{HOMEBREW_PREFIX}'):
-          # Fix 1)
-          #   A setuptools.pth and/or easy-install.pth sitting either in
-          #   /Library/Python/2.7/site-packages or in
-          #   ~/Library/Python/2.7/site-packages can inject the
-          #   /System's Python site-packages. People then report
-          #   "OSError: [Errno 13] Permission denied" because pip/easy_install
-          #   attempts to install into
-          #   /System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python
-          #   See: https://github.com/mxcl/homebrew/issues/14712
-          sys.path = [ p for p in sys.path if not p.startswith('/System') ]
+      if sys.version_info[0] != 3:
+          # This can only happen if the user has set the PYTHONPATH for 3.x and run Python 2.x or vice versa.
+          # Every Python looks at the PYTHONPATH variable and we can't fix it here in sitecustomize.py,
+          # because the PYTHONPATH is evaluated after the sitecustomize.py. Many modules (e.g. PyQt4) are
+          # built only for a specific version of Python and will fail with cryptic error messages.
+          # In the end this means: Don't set the PYTHONPATH permanently if you use different Python versions.
+          exit('Your PYTHONPATH points to a site-packages dir for Python 3.x but you are running Python ' +
+               str(sys.version_info[0]) + '.x!\\n     PYTHONPATH is currently: "' + str(os.environ['PYTHONPATH']) + '"\\n' +
+               '     You should `unset PYTHONPATH` to fix this.')
+      else:
+          # Only do this for a brewed python:
+          opt_executable = '#{opt_bin}/python#{VER}'
+          if os.path.realpath(sys.executable) == os.path.realpath(opt_executable):
+              # Remove /System site-packages, and the Cellar site-packages
+              # which we moved to lib/pythonX.Y/site-packages. Further, remove
+              # HOMEBREW_PREFIX/lib/python because we later addsitedir(...).
+              sys.path = [ p for p in sys.path
+                           if (not p.startswith('/System') and
+                               not p.startswith('#{HOMEBREW_PREFIX}/lib/python') and
+                               not (p.startswith('#{rack}') and p.endswith('site-packages'))) ]
 
-          # Fix 2)
-          #   Remove brewed Python's hard-coded site-packages
-          sys.path.remove('#{site_packages_cellar}')
+              # LINKFORSHARED (and python-config --ldflags) return the
+              # full path to the lib (yes, "Python" is actually the lib, not a
+              # dir) so that third-party software does not need to add the
+              # -F/#{HOMEBREW_PREFIX}/Frameworks switch.
+              # Assume Framework style build (default since months in brew)
+              try:
+                  from _sysconfigdata import build_time_vars
+                  build_time_vars['LINKFORSHARED'] = '-u _PyMac_Error #{opt_prefix}/Frameworks/Python.framework/Versions/#{VER}/Python'
+              except:
+                  pass  # remember: don't print here. Better to fail silently.
 
-      # Fix 3)
-      #   For all Pythons: Tell about homebrew's site-packages location.
-      #   This is needed for Python to parse *.pth files.
-      site.addsitedir('#{site_packages}')
+              # Set the sys.executable to use the opt_prefix
+              sys.executable = opt_executable
+
+          # Tell about homebrew's site-packages location.
+          # This is needed for Python to parse *.pth.
+          import site
+          site.addsitedir('#{site_packages}')
     EOF
   end
 
   def caveats
     text = <<-EOS.undent
-      Homebrew's Python3 framework
-        #{prefix}/Frameworks/Python.framework
-
-      Distribute and Pip have been installed. To update them
-        pip3 install --upgrade distribute
+      Pip has been installed. To update it
         pip3 install --upgrade pip
 
-      To symlink "Idle 3" and the "Python Launcher 3" to ~/Applications
-        `brew linkapps`
-
       You can install Python packages with
-        `pip3 install <your_favorite_package>`
+        pip3 install <package>
 
       They will install into the site-package directory
         #{site_packages}
-      Executable python scripts will be put in:
-        #{scripts_folder}
-      so you may want to put "#{scripts_folder}" in your PATH, too.
 
-      See: https://github.com/mxcl/homebrew/wiki/Homebrew-and-Python
+      See: https://github.com/Homebrew/homebrew/wiki/Homebrew-and-Python
     EOS
 
     # Tk warning only for 10.6
@@ -257,7 +304,7 @@ class Python32 < Formula
     return text
   end
 
-  def test
+  test do
     # Check if sqlite is ok, because we build with --enable-loadable-sqlite-extensions
     # and it can occur that building sqlite silently fails if OSX's sqlite is used.
     system "#{bin}/python#{VER}", "-c", "import sqlite3"
@@ -265,3 +312,56 @@ class Python32 < Formula
     system "#{bin}/python#{VER}", "-c", "import tkinter; root = tkinter.Tk()"
   end
 end
+
+__END__
+# Homebrew's tcl-tk is build in a standard unix fashion (due to link errors)
+# and we have to stop python from searching for frameworks and link against
+# X11.
+
+diff --git a/setup.py b/setup.py
+index d4183d4..9f69520 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1623,9 +1623,6 @@ class PyBuildExt(build_ext):
+         # Rather than complicate the code below, detecting and building
+         # AquaTk is a separate method. Only one Tkinter will be built on
+         # Darwin - either AquaTk, if it is found, or X11 based Tk.
+-        if (host_platform == 'darwin' and
+-            self.detect_tkinter_darwin(inc_dirs, lib_dirs)):
+-            return
+
+         # Assume we haven't found any of the libraries or include files
+         # The versions with dots are used on Unix, and the versions without
+@@ -1671,21 +1668,6 @@ class PyBuildExt(build_ext):
+             if dir not in include_dirs:
+                 include_dirs.append(dir)
+
+-        # Check for various platform-specific directories
+-        if host_platform == 'sunos5':
+-            include_dirs.append('/usr/openwin/include')
+-            added_lib_dirs.append('/usr/openwin/lib')
+-        elif os.path.exists('/usr/X11R6/include'):
+-            include_dirs.append('/usr/X11R6/include')
+-            added_lib_dirs.append('/usr/X11R6/lib64')
+-            added_lib_dirs.append('/usr/X11R6/lib')
+-        elif os.path.exists('/usr/X11R5/include'):
+-            include_dirs.append('/usr/X11R5/include')
+-            added_lib_dirs.append('/usr/X11R5/lib')
+-        else:
+-            # Assume default location for X11
+-            include_dirs.append('/usr/X11/include')
+-            added_lib_dirs.append('/usr/X11/lib')
+
+         # If Cygwin, then verify that X is installed before proceeding
+         if host_platform == 'cygwin':
+@@ -1710,10 +1692,6 @@ class PyBuildExt(build_ext):
+         if host_platform in ['aix3', 'aix4']:
+             libs.append('ld')
+
+-        # Finally, link with the X11 libraries (not appropriate on cygwin)
+-        if host_platform != "cygwin":
+-            libs.append('X11')
+-
+         ext = Extension('_tkinter', ['_tkinter.c', 'tkappinit.c'],
+                         define_macros=[('WITH_APPINIT', 1)] + defs,
+                         include_dirs = include_dirs,

--- a/python32.rb
+++ b/python32.rb
@@ -16,13 +16,13 @@ class Python32 < Formula
   option 'with-brewed-openssl', "Use Homebrew's openSSL instead of the one from OS X"
 
   resource 'setuptools' do
-    url 'https://pypi.python.org/packages/source/s/setuptools/setuptools-2.1.tar.gz'
-    sha1 '3e4a325d807eb0104e98985e7bd9f1ef86fc2efa'
+    url 'https://pypi.python.org/packages/source/s/setuptools/setuptools-5.7.tar.gz'
+    sha1 '807552212cda409b074e0e55630c3801a39eb198'
   end
 
   resource 'pip' do
-    url 'https://pypi.python.org/packages/source/p/pip/pip-1.4.1.tar.gz'
-    sha1 '9766254c7909af6d04739b4a7732cc29e9a48cb0'
+    url 'https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz'
+    sha1 'e6cd9e6f2fd8d28c9976313632ef8aa8ac31249e'
   end
 
   def site_packages_cellar


### PR DESCRIPTION
Python 3.2 is still supported until 2016-02, according to [PEP 392](http://legacy.python.org/dev/peps/pep-0392/).

This package is just a fork of the mainline python3.rb, with downgraded Python, installation of setuptools and pip, and two quirks at installation.

No effort has been done to allow it to coexist with python3, you have to unlink one to link the other.