### PR TITLE
Port 10.10 fixes to gcc46 and gcc47.

### DIFF
--- a/gcc46.rb
+++ b/gcc46.rb
@@ -44,6 +44,12 @@ class Gcc46 < Formula
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
 
+  # Fix 10.10 issues: https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=215251
+  patch :p0 do
+    url "https://trac.macports.org/export/126996/trunk/dports/lang/gcc48/files/patch-10.10.diff"
+    sha1 "4fb0ededa7b8105c3bdffa15469b589b272b7788"
+  end
+
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete 'LD'

--- a/gcc47.rb
+++ b/gcc47.rb
@@ -46,6 +46,12 @@ class Gcc47 < Formula
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
 
+  # Fix 10.10 issues: https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=215251
+  patch :p0 do
+    url "https://trac.macports.org/export/126996/trunk/dports/lang/gcc48/files/patch-10.10.diff"
+    sha1 "4fb0ededa7b8105c3bdffa15469b589b272b7788"
+  end
+
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete 'LD'


### PR DESCRIPTION
The patch for gcc48 applies to gcc46 and gcc47, allowing those to be built on Mac OS X 10.10. Fixes #515, fixes #548.

(See commit 843d2baf2c25e3bebd6b909c7a023a14137b6d72).

Although these are old gcc versions and RVM should use a more recent gcc, it would be nice to keep these older versions available on Yosemite.