### PR TITLE
Boost 1.55

### DIFF
--- a/boost155.rb
+++ b/boost155.rb
@@ -227,4 +227,31 @@ class Boost155 < Formula
 
     s
   end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <boost/algorithm/string.hpp>
+      #include <boost/version.hpp>
+      #include <string>
+      #include <vector>
+      #include <assert.h>
+      using namespace boost::algorithm;
+      using namespace std;
+      int main()
+      {
+        string str("a,b");
+        vector<string> strVec;
+        split(strVec, str, is_any_of(","));
+        assert(strVec.size()==2);
+        assert(strVec[0]=="a");
+        assert(strVec[1]=="b");
+
+        assert(strcmp(BOOST_LIB_VERSION, "1_55") == 0);
+
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-std=c++1y", "-lboost_system", "-o", "test"
+    system "./test"
+  end
 end

--- a/boost155.rb
+++ b/boost155.rb
@@ -1,4 +1,4 @@
-require "formula"
+
 
 class UniversalPython < Requirement
   satisfy(:build_env => false) { archs_for_command("python").universal? }
@@ -28,17 +28,6 @@ class Boost155 < Formula
   homepage "http://www.boost.org"
   url "https://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2"
   sha1 "cef9a0cc7084b1d639e06cd3bc34e4251524c840"
-  revision 2
-
-  head "https://github.com/boostorg/boost.git"
-
-  bottle do
-    cellar :any
-    revision 4
-    sha1 "81b8843487a6f0017fac77b4bf58bdc20f3298fa" => :mavericks
-    sha1 "40089f76eddb25ac418032fa0055b6f0b6d76847" => :mountain_lion
-    sha1 "da4fb2a221fd83f50741f757eefe4bc38b5e910c" => :lion
-  end
 
   env :userpaths
 
@@ -113,7 +102,7 @@ class Boost155 < Formula
   def install
     # https://svn.boost.org/trac/boost/ticket/8841
     if build.with? "mpi" and build.with? "single"
-      raise <<-EOS.undent
+      fail <<-EOS.undent
         Building MPI support for both single and multi-threaded flavors
         is not supported.  Please use "--with-mpi" together with
         "--without-single".
@@ -122,7 +111,7 @@ class Boost155 < Formula
 
     if build.cxx11? and build.with? "mpi" and (build.with? "python" \
                                                or build.with? "python3")
-      raise <<-EOS.undent
+      fail <<-EOS.undent
         Building MPI support for Python using C++11 mode results in
         failure and hence disabled.  Please don"t use this combination
         of options.
@@ -176,8 +165,8 @@ class Boost155 < Formula
     # Boost.Log cannot be built using Apple GCC at the moment. Disabled
     # on such systems.
     without_libraries << "log" if ENV.compiler == :gcc || ENV.compiler == :llvm
-    without_libraries << "python" if (build.without? "python" \
-                                      and build.without? "python3")
+    without_libraries << "python" if build.without? "python" \
+                                      and build.without? "python3"
     without_libraries << "mpi" if build.without? "mpi"
 
     bargs << "--without-libraries=#{without_libraries.join(",")}"

--- a/boost155.rb
+++ b/boost155.rb
@@ -26,7 +26,7 @@ end
 class Boost155 < Formula
   homepage "http://www.boost.org"
   url "https://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2"
-  sha1 "cef9a0cc7084b1d639e06cd3bc34e4251524c840"
+  sha256 "fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52"
 
   env :userpaths
 
@@ -68,12 +68,12 @@ class Boost155 < Formula
     # https://github.com/Homebrew/homebrew/pull/27436
     patch :p2 do
       url "https://github.com/boostorg/atomic/commit/6bb71fdd.diff"
-      sha1 "ca8679011d5293a7fd02cb3b97dde3515b8b2b03"
+      sha256 "eb139160a33d8ef3e810ce3e47da278563d03d7be6d0a75c109f708030a7abcb"
     end
 
     patch :p2 do
       url "https://github.com/boostorg/atomic/commit/e4bde20f.diff"
-      sha1 "b68f5536474c9f543879698299bd4975538a89eb"
+      sha256 "8c5efeea91d44b2a48fdeee9cde71e831dad78f0930e8f65b7223ba0ecdfec9b"
     end
 
     # Patch fixes upstream issue reported here (https://svn.boost.org/trac/boost/ticket/9698).
@@ -82,14 +82,14 @@ class Boost155 < Formula
 
     patch :p2 do
       url "https://github.com/boostorg/chrono/commit/143260d.diff"
-      sha1 "2600214608e7706116831d6ffc302d099ba09950"
+      sha256 "f6f40b576725b15ddfe24497ddcd597f387dfdf674f6dd301b8dcb723593ee22"
     end
 
     # Patch boost::serialization for Clang
     # https://svn.boost.org/trac/boost/ticket/8757
     patch :p1 do
       url "https://gist.githubusercontent.com/philacs/375303205d5f8918e700/raw/d6ded52c3a927b6558984d22efe0a5cf9e59cd8c/0005-Boost.S11n-include-missing-algorithm.patch"
-      sha1 "a37552d48e5c1c0507ee9d48fb82a3fa5e3bc9fa"
+      sha256 "cb134e3982e01ba5b3d5abe51cc8343c9e24ecd34aa4d81f5e8dd4461f593cf1"
     end
   end
 

--- a/boost155.rb
+++ b/boost155.rb
@@ -1,4 +1,4 @@
-require 'formula'
+require "formula"
 
 class UniversalPython < Requirement
   satisfy(:build_env => false) { archs_for_command("python").universal? }
@@ -25,12 +25,12 @@ class UniversalPython3 < Requirement
 end
 
 class Boost155 < Formula
-  homepage 'http://www.boost.org'
-  url 'https://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2'
-  sha1 'cef9a0cc7084b1d639e06cd3bc34e4251524c840'
+  homepage "http://www.boost.org"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2"
+  sha1 "cef9a0cc7084b1d639e06cd3bc34e4251524c840"
   revision 2
 
-  head 'https://github.com/boostorg/boost.git'
+  head "https://github.com/boostorg/boost.git"
 
   bottle do
     cellar :any
@@ -43,10 +43,10 @@ class Boost155 < Formula
   env :userpaths
 
   option :universal
-  option 'with-icu', 'Build regexp engine with icu support'
-  option 'without-single', 'Disable building single-threading variant'
-  option 'without-static', 'Disable building static library variant'
-  option 'with-mpi', 'Build with MPI support'
+  option "with-icu", "Build regexp engine with icu support"
+  option "without-single", "Disable building single-threading variant"
+  option "without-static", "Disable building static library variant"
+  option "with-mpi", "Build with MPI support"
   option :cxx11
 
   depends_on :python => :optional
@@ -58,17 +58,17 @@ class Boost155 < Formula
     odie "boost155: --with-python3 cannot be specified when using --with-python"
   end
 
-  if build.with? 'icu'
+  if build.with? "icu"
     if build.cxx11?
-      depends_on 'icu4c' => 'c++11'
+      depends_on "icu4c" => "c++11"
     else
-      depends_on 'icu4c'
+      depends_on "icu4c"
     end
   end
 
-  if build.with? 'mpi'
+  if build.with? "mpi"
     if build.cxx11?
-      depends_on 'open-mpi' => 'c++11'
+      depends_on "open-mpi" => "c++11"
     else
       depends_on :mpi => [:cc, :cxx, :optional]
     end
@@ -112,19 +112,19 @@ class Boost155 < Formula
 
   def install
     # https://svn.boost.org/trac/boost/ticket/8841
-    if build.with? 'mpi' and build.with? 'single'
+    if build.with? "mpi" and build.with? "single"
       raise <<-EOS.undent
         Building MPI support for both single and multi-threaded flavors
-        is not supported.  Please use '--with-mpi' together with
-        '--without-single'.
+        is not supported.  Please use "--with-mpi" together with
+        "--without-single".
       EOS
     end
 
-    if build.cxx11? and build.with? 'mpi' and (build.with? 'python' \
-                                               or build.with? 'python3')
+    if build.cxx11? and build.with? "mpi" and (build.with? "python" \
+                                               or build.with? "python3")
       raise <<-EOS.undent
         Building MPI support for Python using C++11 mode results in
-        failure and hence disabled.  Please don't use this combination
+        failure and hence disabled.  Please don"t use this combination
         of options.
       EOS
     end
@@ -134,10 +134,10 @@ class Boost155 < Formula
     # Force boost to compile using the appropriate GCC version.
     open("user-config.jam", "a") do |file|
       file.write "using darwin : : #{ENV.cxx} ;\n"
-      file.write "using mpi ;\n" if build.with? 'mpi'
+      file.write "using mpi ;\n" if build.with? "mpi"
 
       # Link against correct version of Python if python3 build was requested
-      if build.with? 'python3'
+      if build.with? "python3"
         py3executable = `which python3`.strip
         py3version = `python3 -c "import sys; print(sys.version[:3])"`.strip
         py3prefix = `python3 -c "import sys; print(sys.prefix)"`.strip
@@ -154,18 +154,18 @@ class Boost155 < Formula
     # we specify libdir too because the script is apparently broken
     bargs = ["--prefix=#{prefix}", "--libdir=#{lib}"]
 
-    if build.with? 'icu'
-      icu4c_prefix = Formula['icu4c'].opt_prefix
+    if build.with? "icu"
+      icu4c_prefix = Formula["icu4c"].opt_prefix
       bargs << "--with-icu=#{icu4c_prefix}"
     else
-      bargs << '--without-icu'
+      bargs << "--without-icu"
     end
 
     # Handle libraries that will not be built.
     without_libraries = []
 
     # The context library is implemented as x86_64 ASM, so it
-    # won't build on PPC or 32-bit builds
+    # won"t build on PPC or 32-bit builds
     # see https://github.com/Homebrew/homebrew/issues/17646
     if Hardware::CPU.ppc? || Hardware::CPU.is_32_bit? || build.universal?
       without_libraries << "context"
@@ -176,11 +176,11 @@ class Boost155 < Formula
     # Boost.Log cannot be built using Apple GCC at the moment. Disabled
     # on such systems.
     without_libraries << "log" if ENV.compiler == :gcc || ENV.compiler == :llvm
-    without_libraries << "python" if (build.without? 'python' \
-                                      and build.without? 'python3')
-    without_libraries << "mpi" if build.without? 'mpi'
+    without_libraries << "python" if (build.without? "python" \
+                                      and build.without? "python3")
+    without_libraries << "mpi" if build.without? "mpi"
 
-    bargs << "--without-libraries=#{without_libraries.join(',')}"
+    bargs << "--without-libraries=#{without_libraries.join(",")}"
 
     args = ["--prefix=#{prefix}",
             "--libdir=#{lib}",
@@ -218,8 +218,8 @@ class Boost155 < Formula
   end
 
   def caveats
-    s = ''
-    # ENV.compiler doesn't exist in caveats. Check library availability
+    s = ""
+    # ENV.compiler doesn"t exist in caveats. Check library availability
     # instead.
     if Dir["#{lib}/libboost_log*"].empty?
       s += <<-EOS.undent

--- a/boost155.rb
+++ b/boost155.rb
@@ -1,5 +1,4 @@
 
-
 class UniversalPython < Requirement
   satisfy(:build_env => false) { archs_for_command("python").universal? }
 

--- a/boost155.rb
+++ b/boost155.rb
@@ -40,8 +40,8 @@ class Boost155 < Formula
 
   depends_on :python => :optional
   depends_on :python3 => :optional
-  depends_on UniversalPython if build.universal? and build.with? "python"
-  depends_on UniversalPython3 if build.universal? and build.with? "python3"
+  depends_on UniversalPython if build.universal? && build.with?("python")
+  depends_on UniversalPython3 if build.universal? && build.with?("python3")
 
   if build.with?("python3") && build.with?("python")
     odie "boost155: --with-python3 cannot be specified when using --with-python"
@@ -101,7 +101,7 @@ class Boost155 < Formula
 
   def install
     # https://svn.boost.org/trac/boost/ticket/8841
-    if build.with? "mpi" and build.with? "single"
+    if build.with?("mpi") && build.with?("single")
       fail <<-EOS.undent
         Building MPI support for both single and multi-threaded flavors
         is not supported.  Please use "--with-mpi" together with
@@ -109,8 +109,8 @@ class Boost155 < Formula
       EOS
     end
 
-    if build.cxx11? and build.with? "mpi" and (build.with? "python" \
-                                               or build.with? "python3")
+    if build.cxx11? && build.with?("mpi") && (build.with?("python") \
+                                               || build.with?("python3"))
       fail <<-EOS.undent
         Building MPI support for Python using C++11 mode results in
         failure and hence disabled.  Please don"t use this combination
@@ -165,8 +165,8 @@ class Boost155 < Formula
     # Boost.Log cannot be built using Apple GCC at the moment. Disabled
     # on such systems.
     without_libraries << "log" if ENV.compiler == :gcc || ENV.compiler == :llvm
-    without_libraries << "python" if build.without? "python" \
-                                      and build.without? "python3"
+    without_libraries << "python" if build.without?("python") \
+                                      && build.without?("python3")
     without_libraries << "mpi" if build.without? "mpi"
 
     bargs << "--without-libraries=#{without_libraries.join(",")}"

--- a/boost155.rb
+++ b/boost155.rb
@@ -1,0 +1,241 @@
+require 'formula'
+
+class UniversalPython < Requirement
+  satisfy(:build_env => false) { archs_for_command("python").universal? }
+
+  def message; <<-EOS.undent
+    A universal build was requested, but Python is not a universal build
+
+    Boost compiles against the Python it finds in the path; if this Python
+    is not a universal build then linking will likely fail.
+    EOS
+  end
+end
+
+class UniversalPython3 < Requirement
+  satisfy(:build_env => false) { archs_for_command("python3").universal? }
+
+  def message; <<-EOS.undent
+    A universal build was requested, but Python 3 is not a universal build
+
+    Boost compiles against the Python 3 it finds in the path; if this Python
+    is not a universal build then linking will likely fail.
+    EOS
+  end
+end
+
+class Boost155 < Formula
+  homepage 'http://www.boost.org'
+  url 'https://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2'
+  sha1 'cef9a0cc7084b1d639e06cd3bc34e4251524c840'
+  revision 2
+
+  head 'https://github.com/boostorg/boost.git'
+
+  bottle do
+    cellar :any
+    revision 4
+    sha1 "81b8843487a6f0017fac77b4bf58bdc20f3298fa" => :mavericks
+    sha1 "40089f76eddb25ac418032fa0055b6f0b6d76847" => :mountain_lion
+    sha1 "da4fb2a221fd83f50741f757eefe4bc38b5e910c" => :lion
+  end
+
+  env :userpaths
+
+  option :universal
+  option 'with-icu', 'Build regexp engine with icu support'
+  option 'without-single', 'Disable building single-threading variant'
+  option 'without-static', 'Disable building static library variant'
+  option 'with-mpi', 'Build with MPI support'
+  option :cxx11
+
+  depends_on :python => :optional
+  depends_on :python3 => :optional
+  depends_on UniversalPython if build.universal? and build.with? "python"
+  depends_on UniversalPython3 if build.universal? and build.with? "python3"
+
+  if build.with?("python3") && build.with?("python")
+    odie "boost155: --with-python3 cannot be specified when using --with-python"
+  end
+
+  if build.with? 'icu'
+    if build.cxx11?
+      depends_on 'icu4c' => 'c++11'
+    else
+      depends_on 'icu4c'
+    end
+  end
+
+  if build.with? 'mpi'
+    if build.cxx11?
+      depends_on 'open-mpi' => 'c++11'
+    else
+      depends_on :mpi => [:cc, :cxx, :optional]
+    end
+  end
+
+  stable do
+    # Patches boost::atomic for LLVM 3.4 as it is used on OS X 10.9 with Xcode 5.1
+    # https://github.com/Homebrew/homebrew/issues/27396
+    # https://github.com/Homebrew/homebrew/pull/27436
+    patch :p2 do
+      url "https://github.com/boostorg/atomic/commit/6bb71fdd.diff"
+      sha1 "ca8679011d5293a7fd02cb3b97dde3515b8b2b03"
+    end
+
+    patch :p2 do
+      url "https://github.com/boostorg/atomic/commit/e4bde20f.diff"
+      sha1 "b68f5536474c9f543879698299bd4975538a89eb"
+    end
+
+    # Patch fixes upstream issue reported here (https://svn.boost.org/trac/boost/ticket/9698).
+    # Will be fixed in Boost 1.56 and can be removed once that release is available.
+    # See this issue (https://github.com/Homebrew/homebrew/issues/30592) for more details.
+
+    patch :p2 do
+      url "https://github.com/boostorg/chrono/commit/143260d.diff"
+      sha1 "2600214608e7706116831d6ffc302d099ba09950"
+    end
+
+    # Patch boost::serialization for Clang
+    # https://svn.boost.org/trac/boost/ticket/8757
+    patch :p1 do
+      url "https://gist.githubusercontent.com/philacs/375303205d5f8918e700/raw/d6ded52c3a927b6558984d22efe0a5cf9e59cd8c/0005-Boost.S11n-include-missing-algorithm.patch"
+      sha1 "a37552d48e5c1c0507ee9d48fb82a3fa5e3bc9fa"
+    end
+  end
+
+  fails_with :llvm do
+    build 2335
+    cause "Dropped arguments to functions when linking with boost"
+  end
+
+  def install
+    # https://svn.boost.org/trac/boost/ticket/8841
+    if build.with? 'mpi' and build.with? 'single'
+      raise <<-EOS.undent
+        Building MPI support for both single and multi-threaded flavors
+        is not supported.  Please use '--with-mpi' together with
+        '--without-single'.
+      EOS
+    end
+
+    if build.cxx11? and build.with? 'mpi' and (build.with? 'python' \
+                                               or build.with? 'python3')
+      raise <<-EOS.undent
+        Building MPI support for Python using C++11 mode results in
+        failure and hence disabled.  Please don't use this combination
+        of options.
+      EOS
+    end
+
+    ENV.universal_binary if build.universal?
+
+    # Force boost to compile using the appropriate GCC version.
+    open("user-config.jam", "a") do |file|
+      file.write "using darwin : : #{ENV.cxx} ;\n"
+      file.write "using mpi ;\n" if build.with? 'mpi'
+
+      # Link against correct version of Python if python3 build was requested
+      if build.with? 'python3'
+        py3executable = `which python3`.strip
+        py3version = `python3 -c "import sys; print(sys.version[:3])"`.strip
+        py3prefix = `python3 -c "import sys; print(sys.prefix)"`.strip
+
+        file.write <<-EOS.undent
+          using python : #{py3version}
+                       : #{py3executable}
+                       : #{py3prefix}/include/python#{py3version}m
+                       : #{py3prefix}/lib ;
+        EOS
+      end
+    end
+
+    # we specify libdir too because the script is apparently broken
+    bargs = ["--prefix=#{prefix}", "--libdir=#{lib}"]
+
+    if build.with? 'icu'
+      icu4c_prefix = Formula['icu4c'].opt_prefix
+      bargs << "--with-icu=#{icu4c_prefix}"
+    else
+      bargs << '--without-icu'
+    end
+
+    # Handle libraries that will not be built.
+    without_libraries = []
+
+    # The context library is implemented as x86_64 ASM, so it
+    # won't build on PPC or 32-bit builds
+    # see https://github.com/Homebrew/homebrew/issues/17646
+    if Hardware::CPU.ppc? || Hardware::CPU.is_32_bit? || build.universal?
+      without_libraries << "context"
+      # The coroutine library depends on the context library.
+      without_libraries << "coroutine"
+    end
+
+    # Boost.Log cannot be built using Apple GCC at the moment. Disabled
+    # on such systems.
+    without_libraries << "log" if ENV.compiler == :gcc || ENV.compiler == :llvm
+    without_libraries << "python" if (build.without? 'python' \
+                                      and build.without? 'python3')
+    without_libraries << "mpi" if build.without? 'mpi'
+
+    bargs << "--without-libraries=#{without_libraries.join(',')}"
+
+    args = ["--prefix=#{prefix}",
+            "--libdir=#{lib}",
+            "-d2",
+            "-j#{ENV.make_jobs}",
+            "--layout=tagged",
+            "--user-config=user-config.jam",
+            "install"]
+
+    if build.with? "single"
+      args << "threading=multi,single"
+    else
+      args << "threading=multi"
+    end
+
+    if build.with? "static"
+      args << "link=shared,static"
+    else
+      args << "link=shared"
+    end
+
+    args << "address-model=32_64" << "architecture=x86" << "pch=off" if build.universal?
+
+    # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11
+    # handling using ENV.cxx11. Using "cxxflags" and "linkflags" still works.
+    if build.cxx11?
+      args << "cxxflags=-std=c++11"
+      if ENV.compiler == :clang
+        args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+      end
+    end
+
+    system "./bootstrap.sh", *bargs
+    system "./b2", *args
+  end
+
+  def caveats
+    s = ''
+    # ENV.compiler doesn't exist in caveats. Check library availability
+    # instead.
+    if Dir["#{lib}/libboost_log*"].empty?
+      s += <<-EOS.undent
+
+      Building of Boost.Log is disabled because it requires newer GCC or Clang.
+      EOS
+    end
+
+    if Hardware::CPU.ppc? || Hardware::CPU.is_32_bit? || build.universal?
+      s += <<-EOS.undent
+
+      Building of Boost.Context and Boost.Coroutine is disabled as they are
+      only supported on x86_64.
+      EOS
+    end
+
+    s
+  end
+end


### PR DESCRIPTION
Boost has been upgraded to 1.56 in main brew tap,
but some software will only build with this specific version.

Based on last commit before upgrade to 1.56: https://github.com/Homebrew/homebrew/commit/a252214738599120551262afe4137152cc28dbb9