### PR TITLE
gcc45 patches for 10.10

### DIFF
--- a/gcc45.rb
+++ b/gcc45.rb
@@ -44,10 +44,25 @@ class Gcc45 < Formula
   depends_on 'cloog-ppl015'
   depends_on 'ecj' if build.include? 'enable-java' or build.include? 'enable-all-languages'
 
-  # Fix libffi for ppc, from MacPorts
+  # Fix libffi for ppc
+  # from MacPorts
   patch :p0 do
     url "http://trac.macports.org/export/110576/trunk/dports/lang/gcc45/files/ppc_fde_encoding.diff"
     sha1 "49e335d085567467155ea6512ffa959a18eab0ef"
+  end
+  
+	# Handle OS X deployment targets correctly (GCC PR target/63810 <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63810>).
+  # from MacPorts
+  patch :p0 do
+    url "https://trac.macports.org/export/129382/trunk/dports/lang/gcc45/files/macosx-version-min.patch"
+    sha1 "79a3314759a33059cd6e3a078fdb3f5ee957d2e6"
+  end
+  
+  # Don't link with "-flat_namespace -undefined suppress" on Yosemite and later (#45483)
+  # from MacPorts
+  patch :p0 do
+    url "https://trac.macports.org/export/129382/trunk/dports/lang/gcc45/files/yosemite-libtool.patch"
+    sha1 "49efed6a1c90a22d604d0ff6850271ad53c1205e"
   end
 
   fails_with :llvm

--- a/gcc45.rb
+++ b/gcc45.rb
@@ -50,14 +50,14 @@ class Gcc45 < Formula
     url "http://trac.macports.org/export/110576/trunk/dports/lang/gcc45/files/ppc_fde_encoding.diff"
     sha1 "49e335d085567467155ea6512ffa959a18eab0ef"
   end
-  
-	# Handle OS X deployment targets correctly (GCC PR target/63810 <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63810>).
+
+  # Handle OS X deployment targets correctly (GCC PR target/63810 <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63810>).
   # from MacPorts
   patch :p0 do
     url "https://trac.macports.org/export/129382/trunk/dports/lang/gcc45/files/macosx-version-min.patch"
     sha1 "79a3314759a33059cd6e3a078fdb3f5ee957d2e6"
   end
-  
+
   # Don't link with "-flat_namespace -undefined suppress" on Yosemite and later (#45483)
   # from MacPorts
   patch :p0 do


### PR DESCRIPTION
Fixes #581. These patches enable support for a two-digit minor OS X versions introduced with 10.10 Yosemite.