### PR TITLE
Dcmtk snapshot

### DIFF
--- a/dcmtk-snapshot.rb
+++ b/dcmtk-snapshot.rb
@@ -1,0 +1,38 @@
+require 'formula'
+
+# Formula copied from dcmtk formula
+class DcmtkSnapshot < Formula
+  homepage 'http://dicom.offis.de/dcmtk.php.en'
+  url 'http://dicom.offis.de/download/dcmtk/snapshot/dcmtk-3.6.1_20140617.tar.gz'
+  version "3.6.1-20140617"
+  sha256 'c0aab5a3809e20f8b4eae2f181c77a1668d0665e86a590821a59808f45656cdc'
+
+  bottle do
+    sha1 "8c89405648fc176e34716a6e786444da20765b12" => :yosemite
+  end
+
+  option 'with-docs', 'Install development libraries/headers and HTML docs'
+  option 'with-openssl', 'Configure DCMTK with support for OpenSSL'
+
+  depends_on 'cmake' => :build
+  depends_on "libpng"
+  depends_on 'libtiff'
+  depends_on "doxygen" => :build if build.with? "docs"
+
+  conflicts_with "dcmtk", :because => "Differing versions of same package"
+
+  def install
+    ENV.m64 if MacOS.prefer_64_bit?
+
+    args = std_cmake_args
+    args << '-DDCMTK_WITH_DOXYGEN=YES' if build.with? "docs"
+    args << '-DDCMTK_WITH_OPENSSL=YES' if build.with? "openssl"
+    args << '..'
+
+    mkdir 'build' do
+      system 'cmake', *args
+      system 'make DOXYGEN' if build.with? "docs"
+      system 'make install'
+    end
+  end
+end

--- a/dcmtk361.rb
+++ b/dcmtk361.rb
@@ -1,23 +1,22 @@
-require 'formula'
-
 # Formula copied from dcmtk formula
 class Dcmtk361 < Formula
-  homepage 'http://dicom.offis.de/dcmtk.php.en'
-  url 'http://dicom.offis.de/download/dcmtk/snapshot/dcmtk-3.6.1_20140617.tar.gz'
+  homepage "http://dicom.offis.de/dcmtk.php.en"
+  url "http://dicom.offis.de/download/dcmtk/snapshot/dcmtk-3.6.1_20140617.tar.gz"
   version "3.6.1-20140617"
-  sha256 'c0aab5a3809e20f8b4eae2f181c77a1668d0665e86a590821a59808f45656cdc'
+  sha256 "c0aab5a3809e20f8b4eae2f181c77a1668d0665e86a590821a59808f45656cdc"
 
   bottle do
-    sha1 "8c89405648fc176e34716a6e786444da20765b12" => :yosemite
+    sha1 "ae36fa23b94d89b8e3d4a986b6f205bc287ce0e1" => :yosemite
   end
 
-  option 'with-docs', 'Install development libraries/headers and HTML docs'
-  option 'with-openssl', 'Configure DCMTK with support for OpenSSL'
+  option "with-docs", "Install development libraries/headers and HTML docs"
+  option "with-openssl", "Configure DCMTK with support for OpenSSL"
 
-  depends_on 'cmake' => :build
+  depends_on "cmake" => :build
   depends_on "libpng"
-  depends_on 'libtiff'
+  depends_on "libtiff"
   depends_on "doxygen" => :build if build.with? "docs"
+  depends_on "openssl" => :optional
 
   conflicts_with "dcmtk", :because => "Differing versions of same package"
 
@@ -25,14 +24,14 @@ class Dcmtk361 < Formula
     ENV.m64 if MacOS.prefer_64_bit?
 
     args = std_cmake_args
-    args << '-DDCMTK_WITH_DOXYGEN=YES' if build.with? "docs"
-    args << '-DDCMTK_WITH_OPENSSL=YES' if build.with? "openssl"
-    args << '..'
+    args << "-DDCMTK_WITH_DOXYGEN=YES" if build.with? "docs"
+    args << "-DDCMTK_WITH_OPENSSL=YES" if build.with? "openssl"
+    args << ".."
 
-    mkdir 'build' do
-      system 'cmake', *args
-      system 'make DOXYGEN' if build.with? "docs"
-      system 'make install'
+    mkdir "build" do
+      system "cmake", *args
+      system "make", "DOXYGEN" if build.with? "docs"
+      system "make", "install"
     end
   end
 end

--- a/dcmtk361.rb
+++ b/dcmtk361.rb
@@ -11,12 +11,15 @@ class Dcmtk361 < Formula
 
   option "with-docs", "Install development libraries/headers and HTML docs"
   option "with-openssl", "Configure DCMTK with support for OpenSSL"
+  option "with-libiconv", "Build with libiconv (updated version available from homebrew-dupes)"
+  option "with-system-libiconv", "If the default libiconv should be used."
 
   depends_on "cmake" => :build
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "doxygen" => :build if build.with? "docs"
   depends_on "openssl" => :optional
+  depends_on "libiconv" => :optional if build.with? "libiconv" unless build.with? "system-libiconv"
 
   conflicts_with "dcmtk", :because => "Differing versions of same package"
 
@@ -26,6 +29,8 @@ class Dcmtk361 < Formula
     args = std_cmake_args
     args << "-DDCMTK_WITH_DOXYGEN=YES" if build.with? "docs"
     args << "-DDCMTK_WITH_OPENSSL=YES" if build.with? "openssl"
+    args << "--with-libiconv" if build.with? "libiconv"
+    args << "--with-libiconvinc=" + Formula["libiconv"].opt_prefix.to_s unless build.with? "system-libiconv"
     args << ".."
 
     mkdir "build" do

--- a/dcmtk361.rb
+++ b/dcmtk361.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 # Formula copied from dcmtk formula
-class DcmtkSnapshot < Formula
+class Dcmtk361 < Formula
   homepage 'http://dicom.offis.de/dcmtk.php.en'
   url 'http://dicom.offis.de/download/dcmtk/snapshot/dcmtk-3.6.1_20140617.tar.gz'
   version "3.6.1-20140617"


### PR DESCRIPTION
The unreleased 3.6.1 version of dcmtk is commonly used. Releases of the project have been stalled for a long time and this (latest) snapshot is frequently referenced.