### PR TITLE
Update tomcat7 to 7.0.59

### DIFF
--- a/tomcat7.rb
+++ b/tomcat7.rb
@@ -2,15 +2,15 @@ require 'formula'
 
 class Tomcat7 < Formula
   homepage "http://tomcat.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.tar.gz"
-  sha1 "49ffffe9c2e534e66f81b3173cdbf7e305a75fe2"
+  url "http://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-7/v7.0.59/bin/apache-tomcat-7.0.59.tar.gz"
+  sha1 "c9f8d87a212091c33027f122aba90b78eb1c0a01"
 
   option "with-fulldocs", "Install full documentation locally"
 
   resource "fulldocs" do
-    url "http://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57-fulldocs.tar.gz"
-    version "7.0.57"
-    sha1 "4aba0b393134a230f01ea051c8dbde08fcf08611"
+    url "http://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-7/v7.0.59/bin/apache-tomcat-7.0.59-fulldocs.tar.gz"
+    version "7.0.59"
+    sha1 "96852de4949a1765b1a5478c8c586220bfc16377"
   end
 
   # Keep log folders


### PR DESCRIPTION
Older versions of tomcat7 are no longer available on apache, causing a 404 to be displayed. Quick fix is to bump to latest version (7.0.59).

For clarification running `brew install tomcat7` was returning the following error on my system:

```bash
$ brew install tomcat7
==> Installing tomcat7 from homebrew/homebrew-versions
==> Downloading http://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.tar.gz
==> Best Mirror http://mirror.tcpdiag.net/apache/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "tomcat7"
Download failed: http://mirror.tcpdiag.net/apache/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.tar.gz
l-sb8x1qfdv7-m:atlas mhayes3$ brew install -v https://raw.githubusercontent.com/asaph/homebrew-versions/tomcat-7.0.57/tomcat7.rb
/usr/bin/curl -fLA Homebrew 0.9.5 (Ruby 2.0.0-481; Mac OS X 10.9.5) https://raw.githubusercontent.com/asaph/homebrew-versions/tomcat-7.0.57/tomcat7.rb -o /Library/Caches/Homebrew/Formula/tomcat7.rb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   913  100   913    0     0   1488      0 --:--:-- --:--:-- --:--:--  1486
==> Downloading http://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.tar.gz
==> Best Mirror http://mirror.olnevhost.net/pub/apache/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.tar.gz
/usr/bin/curl -fLA Homebrew 0.9.5 (Ruby 2.0.0-481; Mac OS X 10.9.5) http://mirror.olnevhost.net/pub/apache/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.tar.gz -C 0 -o /Library/Caches/Homebrew/tomcat7-7.0.57.tar.gz.incomplete
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "tomcat7"
```