### PR TITLE
Add swig 3.0.4

### DIFF
--- a/swig304.rb
+++ b/swig304.rb
@@ -1,0 +1,41 @@
+class Swig304 < Formula
+  homepage "http://www.swig.org/"
+  url "https://downloads.sourceforge.net/project/swig/swig/swig-3.0.4/swig-3.0.4.tar.gz"
+  sha1 "088b2fb1f3167703f79fb187fdb3b80513426eb1"
+
+  option :universal
+
+  depends_on "pcre"
+
+  def install
+    ENV.universal_binary if build.universal?
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      int add(int x, int y)
+      {
+        return x + y;
+      }
+    EOS
+    (testpath/"test.i").write <<-EOS.undent
+      %module test
+      %inline %{
+      extern int add(int x, int y);
+      %}
+    EOS
+    (testpath/"run.rb").write <<-EOS.undent
+      require "./test"
+      puts Test.add(1, 1)
+    EOS
+    system "#{bin}/swig", "-ruby", "test.i"
+    system ENV.cc, "-c", "test.c"
+    system ENV.cc, "-c", "test_wrap.c", "-I/System/Library/Frameworks/Ruby.framework/Headers/"
+    system ENV.cc, "-bundle", "-flat_namespace", "-undefined", "suppress", "test.o", "test_wrap.o", "-o", "test.bundle"
+    assert_equal "2", shell_output("ruby run.rb").strip
+  end
+end


### PR DESCRIPTION
This is the same as the 3.0.5 file in the main branch, minus the bottles and
with a different link and hash.

Why: M2Crypto fails to build with swig 3.0.5, which breaks a number of projects.