### PR TITLE
Add additional HTTP mirror for 'gmp4'

### DIFF
--- a/gmp4.rb
+++ b/gmp4.rb
@@ -6,6 +6,7 @@ class Gmp4 < Formula
   url 'ftp://ftp.gmplib.org/pub/gmp-4.3.2/gmp-4.3.2.tar.bz2'
   mirror 'ftp://gcc.gnu.org/pub/gcc/infrastructure/gmp-4.3.2.tar.bz2'
   mirror 'http://mirror.anl.gov/pub/gnu/gmp/gmp-4.3.2.tar.bz2'
+  mirror 'http://gnu.mirrors.hoobly.com/gnu/gmp/gmp-4.3.2.tar.bz2'
   sha1 'c011e8feaf1bb89158bd55eaabd7ef8fdd101a2c'
 
   bottle do


### PR DESCRIPTION
FTP servers (likely because of my office network restrictions)
were resetting the connection.  The existing HTTP mirror is returning 403:

```shell

    wget 'http://mirror.anl.gov/pub/gnu/gmp/gmp-4.3.2.tar.bz2'
    --2015-02-11 18:00:04--  http://mirror.anl.gov/pub/gnu/gmp/gmp-4.3.2.tar.bz2
    Resolving mirror.anl.gov... 146.137.96.7, 2620::dc0:1800:214:4fff:fe7d:1b9
    Connecting to mirror.anl.gov|146.137.96.7|:80... connected.
    HTTP request sent, awaiting response... 403 Forbidden
    2015-02-11 18:00:04 ERROR 403: Forbidden.

```

I have added an additional HTTP mirror, which fixed the connection issue for me.