### PR TITLE
tomcat 7.0.59

### DIFF
--- a/tomcat7.rb
+++ b/tomcat7.rb
@@ -2,15 +2,15 @@ require 'formula'
 
 class Tomcat7 < Formula
   homepage "http://tomcat.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.tar.gz"
-  sha1 "49ffffe9c2e534e66f81b3173cdbf7e305a75fe2"
+  url "http://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-7/v7.0.59/bin/apache-tomcat-7.0.59.tar.gz"
+  sha1 "c9f8d87a212091c33027f122aba90b78eb1c0a01"
 
   option "with-fulldocs", "Install full documentation locally"
 
   resource "fulldocs" do
-    url "http://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57-fulldocs.tar.gz"
-    version "7.0.57"
-    sha1 "4aba0b393134a230f01ea051c8dbde08fcf08611"
+    url "http://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-7/v7.0.59/bin/apache-tomcat-7.0.59-fulldocs.tar.gz"
+    version "7.0.59"
+    sha1 "96852de4949a1765b1a5478c8c586220bfc16377"
   end
 
   # Keep log folders

--- a/tomcat7.rb
+++ b/tomcat7.rb
@@ -1,4 +1,4 @@
-require 'formula'
+require "formula"
 
 class Tomcat7 < Formula
   homepage "http://tomcat.apache.org/"
@@ -14,17 +14,17 @@ class Tomcat7 < Formula
   end
 
   # Keep log folders
-  skip_clean 'libexec'
+  skip_clean "libexec"
 
   def install
     # Remove Windows scripts
-    rm_rf Dir['bin/*.bat']
+    rm_rf Dir["bin/*.bat"]
 
     # Install files
-    prefix.install %w{ NOTICE LICENSE RELEASE-NOTES RUNNING.txt }
-    libexec.install Dir['*']
+    prefix.install %w[ NOTICE LICENSE RELEASE-NOTES RUNNING.txt ]
+    libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/catalina.sh" => "catalina"
 
-    (share/'fulldocs').install resource('fulldocs') if build.with? 'fulldocs'
+    (share/"fulldocs").install resource("fulldocs") if build.with? "fulldocs"
   end
 end


### PR DESCRIPTION
Upgraded tomcat7 recipe to use version 7.0.59, as 7.0.57 is no longer in the download mirrors.
Ran rubocop and addressed all warnings.