### PR TITLE
Docker 1.4.1 & Boot2Docker 1.4.1 Support

### DIFF
--- a/boot2docker141.rb
+++ b/boot2docker141.rb
@@ -8,9 +8,9 @@ class Boot2docker < Formula
   head "https://github.com/boot2docker/boot2docker-cli.git"
 
   bottle do
-    sha1 "67313ebf6f2cd0653d7f017ae783e92da1c9e44f" => :yosemite
-    sha1 "68fe92df4290f9494ab6ce10cfe37e5b154b2abc" => :mavericks
-    sha1 "ccdf2d4ed162f2bb49141e89853933dc8b64e9a1" => :mountain_lion
+    sha1 "9e23c1d530e7ef94fbac0c02eb02fecb943c8f7b" => :yosemite
+    sha1 "72dc462b5bf76c4c69e35aef14e6d4ffa7bbcb6e" => :mavericks
+    sha1 "82da9c5a4f56d4fe5e4fd08d1a2098cb40842bc5" => :mountain_lion
   end
 
   depends_on "docker" => :recommended

--- a/boot2docker141.rb
+++ b/boot2docker141.rb
@@ -1,19 +1,9 @@
-require "formula"
-
-class Boot2docker < Formula
+class Boot2docker141 < Formula
   homepage "https://github.com/boot2docker/boot2docker-cli"
-  # Boot2docker and docker are generally updated at the same time.
-  # Please update the version of docker too
   url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.4.1"
   head "https://github.com/boot2docker/boot2docker-cli.git"
 
-  bottle do
-    sha1 "9e23c1d530e7ef94fbac0c02eb02fecb943c8f7b" => :yosemite
-    sha1 "72dc462b5bf76c4c69e35aef14e6d4ffa7bbcb6e" => :mavericks
-    sha1 "82da9c5a4f56d4fe5e4fd08d1a2098cb40842bc5" => :mountain_lion
-  end
-
-  depends_on "docker" => :recommended
+  depends_on "docker141" => :recommended
   depends_on "go" => :build
 
   def install

--- a/boot2docker141.rb
+++ b/boot2docker141.rb
@@ -1,0 +1,55 @@
+require "formula"
+
+class Boot2docker < Formula
+  homepage "https://github.com/boot2docker/boot2docker-cli"
+  # Boot2docker and docker are generally updated at the same time.
+  # Please update the version of docker too
+  url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.4.1"
+  head "https://github.com/boot2docker/boot2docker-cli.git"
+
+  bottle do
+    sha1 "67313ebf6f2cd0653d7f017ae783e92da1c9e44f" => :yosemite
+    sha1 "68fe92df4290f9494ab6ce10cfe37e5b154b2abc" => :mavericks
+    sha1 "ccdf2d4ed162f2bb49141e89853933dc8b64e9a1" => :mountain_lion
+  end
+
+  depends_on "docker" => :recommended
+  depends_on "go" => :build
+
+  def install
+    (buildpath + "src/github.com/boot2docker/boot2docker-cli").install Dir[buildpath/"*"]
+
+    cd "src/github.com/boot2docker/boot2docker-cli" do
+      ENV["GOPATH"] = buildpath
+      system "go", "get", "-d"
+
+      ENV["GIT_DIR"] = cached_download/".git"
+      system "make", "goinstall"
+    end
+
+    bin.install "bin/boot2docker-cli" => "boot2docker"
+  end
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/boot2docker</string>
+        <string>up</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/boot2docker", "version"
+  end
+end

--- a/docker141.rb
+++ b/docker141.rb
@@ -7,9 +7,9 @@ class Docker < Formula
   url "https://github.com/docker/docker.git", :tag => "v1.4.1"
 
   bottle do
-    sha1 "aa72e6dd64d8b2f6f4f733e20cd2bdaa1bb923e3" => :yosemite
-    sha1 "18c1660c6baa6b9b03c0acb33627c70f98856e6f" => :mavericks
-    sha1 "3d40663273ceda30b0bfac70447742d2ea11fcd4" => :mountain_lion
+    sha1 "71a4d59ee4d12d7cff6e1125b154596e9de1d271" => :yosemite
+    sha1 "aab3097942193361d2a1c0958462103425891255" => :mavericks
+    sha1 "71cf01001d2cfed720a1e54fddcc47108ec087f7" => :mountain_lion
   end
 
   option "without-completions", "Disable bash/zsh completions"

--- a/docker141.rb
+++ b/docker141.rb
@@ -1,16 +1,6 @@
-require "formula"
-
-class Docker < Formula
+class Docker141 < Formula
   homepage "https://www.docker.com/"
-  # Boot2docker and docker are generally updated at the same time.
-  # Please update the version of boot2docker too
   url "https://github.com/docker/docker.git", :tag => "v1.4.1"
-
-  bottle do
-    sha1 "71a4d59ee4d12d7cff6e1125b154596e9de1d271" => :yosemite
-    sha1 "aab3097942193361d2a1c0958462103425891255" => :mavericks
-    sha1 "71cf01001d2cfed720a1e54fddcc47108ec087f7" => :mountain_lion
-  end
 
   option "without-completions", "Disable bash/zsh completions"
 

--- a/docker141.rb
+++ b/docker141.rb
@@ -1,0 +1,36 @@
+require "formula"
+
+class Docker < Formula
+  homepage "https://www.docker.com/"
+  # Boot2docker and docker are generally updated at the same time.
+  # Please update the version of boot2docker too
+  url "https://github.com/docker/docker.git", :tag => "v1.4.1"
+
+  bottle do
+    sha1 "aa72e6dd64d8b2f6f4f733e20cd2bdaa1bb923e3" => :yosemite
+    sha1 "18c1660c6baa6b9b03c0acb33627c70f98856e6f" => :mavericks
+    sha1 "3d40663273ceda30b0bfac70447742d2ea11fcd4" => :mountain_lion
+  end
+
+  option "without-completions", "Disable bash/zsh completions"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GIT_DIR"] = cached_download/".git"
+    ENV["AUTO_GOPATH"] = "1"
+    ENV["DOCKER_CLIENTONLY"] = "1"
+
+    system "hack/make.sh", "dynbinary"
+    bin.install "bundles/#{version}/dynbinary/docker-#{version}" => "docker"
+
+    if build.with? "completions"
+      bash_completion.install "contrib/completion/bash/docker"
+      zsh_completion.install "contrib/completion/zsh/_docker"
+    end
+  end
+
+  test do
+    system "#{bin}/docker", "--version"
+  end
+end


### PR DESCRIPTION
Historical versions of Homebrew files were:

    fc4e7d263eaea48885bb9425c8a2303e8fe39e2b Library/Formula/docker.rb
    2360263c3fb1c60d8fc4f1bba393611d062d2d34 Library/Formula/boot2docker.rb