### PR TITLE
llvm36: Improve scan-build installation

### DIFF
--- a/llvm36.rb
+++ b/llvm36.rb
@@ -239,6 +239,10 @@ class Llvm36 < Formula
     system "make", "-C", libcxx_buildpath, "install", *libcxx_make_args
 
     (share/"clang-#{ver}/tools").install Dir["tools/clang/tools/scan-{build,view}"]
+    inreplace share/"clang-#{ver}/tools/scan-build/scan-build", "$RealBin/bin/clang", install_prefix/"bin/clang"
+    ln_s share/"clang-#{ver}/tools/scan-build/scan-build", install_prefix/"bin"
+    ln_s share/"clang-#{ver}/tools/scan-view/scan-view", install_prefix/"bin"
+    (install_prefix/"share/man/man1").install share/"clang-#{ver}/tools/scan-build/scan-build.1"
 
     (lib/"python2.7/site-packages").install "bindings/python/llvm" => "llvm-#{ver}",
                                             clang_buildpath/"bindings/python/clang" => "clang-#{ver}"


### PR DESCRIPTION
Make scan-build-3.6 available from the bin directory in the path by
creating symlinks to the actual installation.  It is necessary to do it
this way because the scan-build program resolves the symlink and finds
its helper files that way.

Related bugs: #558, Homebrew/homebrew#26902, Homebrew/homebrew#33777