### PR TITLE
archive boot2docker 1.3.3 in homebrew/versions

### DIFF
--- a/boot2docker133.rb
+++ b/boot2docker133.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Boot2docker133 < Formula
   homepage "https://github.com/boot2docker/boot2docker-cli"
   # Boot2docker and docker are generally updated at the same time.

--- a/boot2docker133.rb
+++ b/boot2docker133.rb
@@ -2,7 +2,7 @@ class Boot2docker133 < Formula
   homepage "https://github.com/boot2docker/boot2docker-cli"
   # Boot2docker and docker are generally updated at the same time.
   # Please update the version of docker too
-  url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.3.3"
+  url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.3.3", :release => "81bd2efb357cf84edb928883c0df43b1334e2860"
 
   depends_on "docker" => :recommended
   depends_on "go" => :build

--- a/boot2docker133.rb
+++ b/boot2docker133.rb
@@ -2,7 +2,7 @@ class Boot2docker133 < Formula
   homepage "https://github.com/boot2docker/boot2docker-cli"
   # Boot2docker and docker are generally updated at the same time.
   # Please update the version of docker too
-  url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.3.3", :release => "81bd2efb357cf84edb928883c0df43b1334e2860"
+  url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.3.3", :revision => "81bd2efb357cf84edb928883c0df43b1334e2860"
 
   depends_on "docker" => :recommended
   depends_on "go" => :build

--- a/boot2docker133.rb
+++ b/boot2docker133.rb
@@ -1,0 +1,55 @@
+require "formula"
+
+class Boot2docker < Formula
+  homepage "https://github.com/boot2docker/boot2docker-cli"
+  # Boot2docker and docker are generally updated at the same time.
+  # Please update the version of docker too
+  url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.3.3"
+  head "https://github.com/boot2docker/boot2docker-cli.git"
+
+  bottle do
+    sha1 "67313ebf6f2cd0653d7f017ae783e92da1c9e44f" => :yosemite
+    sha1 "68fe92df4290f9494ab6ce10cfe37e5b154b2abc" => :mavericks
+    sha1 "ccdf2d4ed162f2bb49141e89853933dc8b64e9a1" => :mountain_lion
+  end
+
+  depends_on "docker" => :recommended
+  depends_on "go" => :build
+
+  def install
+    (buildpath + "src/github.com/boot2docker/boot2docker-cli").install Dir[buildpath/"*"]
+
+    cd "src/github.com/boot2docker/boot2docker-cli" do
+      ENV["GOPATH"] = buildpath
+      system "go", "get", "-d"
+
+      ENV["GIT_DIR"] = cached_download/".git"
+      system "make", "goinstall"
+    end
+
+    bin.install "bin/boot2docker-cli" => "boot2docker"
+  end
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/boot2docker</string>
+        <string>up</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/boot2docker", "version"
+  end
+end

--- a/boot2docker133.rb
+++ b/boot2docker133.rb
@@ -3,13 +3,6 @@ class Boot2docker133 < Formula
   # Boot2docker and docker are generally updated at the same time.
   # Please update the version of docker too
   url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.3.3"
-  head "https://github.com/boot2docker/boot2docker-cli.git"
-
-  bottle do
-    sha1 "67313ebf6f2cd0653d7f017ae783e92da1c9e44f" => :yosemite
-    sha1 "68fe92df4290f9494ab6ce10cfe37e5b154b2abc" => :mavericks
-    sha1 "ccdf2d4ed162f2bb49141e89853933dc8b64e9a1" => :mountain_lion
-  end
 
   depends_on "docker" => :recommended
   depends_on "go" => :build

--- a/boot2docker133.rb
+++ b/boot2docker133.rb
@@ -4,7 +4,7 @@ class Boot2docker133 < Formula
   # Please update the version of docker too
   url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.3.3", :revision => "81bd2efb357cf84edb928883c0df43b1334e2860"
 
-  depends_on "docker" => :recommended
+  depends_on "docker133" => :recommended
   depends_on "go" => :build
 
   def install

--- a/boot2docker133.rb
+++ b/boot2docker133.rb
@@ -1,6 +1,6 @@
 require "formula"
 
-class Boot2docker < Formula
+class Boot2docker133 < Formula
   homepage "https://github.com/boot2docker/boot2docker-cli"
   # Boot2docker and docker are generally updated at the same time.
   # Please update the version of docker too


### PR DESCRIPTION
Provide boot2docker v1.3.3 in homebrew/versions, so that other tools like Google Cloud can work on Mac OS X.

Re: #731