### PR TITLE
Docker 1.5.0 formula

### DIFF
--- a/docker150.rb
+++ b/docker150.rb
@@ -1,0 +1,27 @@
+class Docker150 < Formula
+  homepage "https://www.docker.com/"
+  url "https://github.com/docker/docker.git",
+      :tag => "v1.5.0",
+      :revision => "a8a31eff10544860d2188dddabdee4d727545796"
+
+  option "without-completions", "Disable bash/zsh completions"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["AUTO_GOPATH"] = "1"
+    ENV["DOCKER_CLIENTONLY"] = "1"
+
+    system "hack/make.sh", "dynbinary"
+    bin.install "bundles/#{version}/dynbinary/docker-#{version}" => "docker"
+
+    if build.with? "completions"
+      bash_completion.install "contrib/completion/bash/docker"
+      zsh_completion.install "contrib/completion/zsh/_docker"
+    end
+  end
+
+  test do
+    system "#{bin}/docker", "--version"
+  end
+end


### PR DESCRIPTION
Docker 1.5.0 is the version distributed on RedHat 7.1 and available through EPEL for RedHat 6. 

https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/7.1_Release_Notes/chap-Red_Hat_Enterprise_Linux-7.1_Release_Notes-Linux_Containers_with_Docker_Format.html

These formula is based on this commit of the docker main formula: 
https://github.com/Homebrew/homebrew/blob/5878311e0435d3c8ee2aecadb9e07882d2925829/Library/Formula/docker.rb
