### PR TITLE
elasticsearch: changed domains for all formulae

### DIFF
--- a/elasticsearch-0.20.rb
+++ b/elasticsearch-0.20.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Elasticsearch020 < Formula
   homepage 'https://www.elastic.co/products/elasticsearch'
   url 'https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-0.20.6.tar.gz'
-  sha1 'f66a778ad94ea1dd69d18f8f89ce32c2383898eb'
+  sha256 '534b9fdb2fa9031f539b19cc4cfc1345bbbb013a285a21105ca87348b96b3389'
 
   def cluster_name
     "elasticsearch_#{ENV['USER']}"

--- a/elasticsearch-0.20.rb
+++ b/elasticsearch-0.20.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Elasticsearch020 < Formula
-  homepage 'http://www.elasticsearch.org'
-  url 'http://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.20.6.tar.gz'
+  homepage 'https://www.elastic.co/products/elasticsearch'
+  url 'http://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-0.20.6.tar.gz'
   sha1 'f66a778ad94ea1dd69d18f8f89ce32c2383898eb'
 
   def cluster_name

--- a/elasticsearch-0.20.rb
+++ b/elasticsearch-0.20.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Elasticsearch020 < Formula
   homepage 'https://www.elastic.co/products/elasticsearch'
-  url 'http://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-0.20.6.tar.gz'
+  url 'https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-0.20.6.tar.gz'
   sha1 'f66a778ad94ea1dd69d18f8f89ce32c2383898eb'
 
   def cluster_name

--- a/elasticsearch090.rb
+++ b/elasticsearch090.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Elasticsearch090 < Formula
   homepage 'https://www.elastic.co/products/elasticsearch'
   url 'https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-0.90.13.tar.gz'
-  sha1 'bc4f805f052fbefbd2b4c392b108e62f08bf8380'
+  sha256 '82904d4c564fc893a1cfc0deb4526073900072a3f4667b995881a2ec5cdfdb43'
 
   def cluster_name
     "elasticsearch_#{ENV['USER']}"

--- a/elasticsearch090.rb
+++ b/elasticsearch090.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Elasticsearch090 < Formula
-  homepage 'http://www.elasticsearch.org'
-  url 'https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.13.tar.gz'
+  homepage 'https://www.elastic.co/products/elasticsearch'
+  url 'https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-0.90.13.tar.gz'
   sha1 'bc4f805f052fbefbd2b4c392b108e62f08bf8380'
 
   def cluster_name

--- a/elasticsearch11.rb
+++ b/elasticsearch11.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Elasticsearch11 < Formula
-  homepage "http://www.elasticsearch.org"
-  url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.1.2.tar.gz"
+  homepage "https://www.elastic.co/products/elasticsearch"
+  url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.1.2.tar.gz"
   sha1 "04200ebfc7f12c8cd144b599fa58329b0cfa9d0e"
 
   def cluster_name

--- a/elasticsearch11.rb
+++ b/elasticsearch11.rb
@@ -3,7 +3,7 @@ require "formula"
 class Elasticsearch11 < Formula
   homepage "https://www.elastic.co/products/elasticsearch"
   url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.1.2.tar.gz"
-  sha1 "04200ebfc7f12c8cd144b599fa58329b0cfa9d0e"
+  sha256 "adcea279ff2ffbe270ae86c6b563641afa93f1f5bf2ffe33e7a7c8ac2baf9527"
 
   def cluster_name
     "elasticsearch_#{ENV['USER']}"

--- a/elasticsearch12.rb
+++ b/elasticsearch12.rb
@@ -1,6 +1,6 @@
 class Elasticsearch12 < Formula
-  homepage "http://www.elasticsearch.org"
-  url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.2.4.tar.gz"
+  homepage "https://www.elastic.co/products/elasticsearch"
+  url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.2.4.tar.gz"
   sha1 "c8bbe1f1975ffb6774744fadd0abb78616e96904"
 
   bottle do

--- a/elasticsearch12.rb
+++ b/elasticsearch12.rb
@@ -1,7 +1,7 @@
 class Elasticsearch12 < Formula
   homepage "https://www.elastic.co/products/elasticsearch"
   url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.2.4.tar.gz"
-  sha1 "c8bbe1f1975ffb6774744fadd0abb78616e96904"
+  sha256 "07c298cb4dae634a2514f6022cd28533be0d86e3a2d0ad75ee6f24ff49b2e22f"
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles-versions"

--- a/elasticsearch13.rb
+++ b/elasticsearch13.rb
@@ -1,7 +1,7 @@
 class Elasticsearch13 < Formula
   homepage "http://www.elastic.c://www.elastic.co/products/elasticsearch"
   url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.3.9.tar.gz"
-  sha1 "ee6013d33d6371184fae970ff8f1c2d76c0834a0"
+  sha256 "9b12ceba35c4a48e3e0fdc93f0676917d10acb5ee9264e9f2f9efc1a73e540bd"
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles-versions"

--- a/elasticsearch13.rb
+++ b/elasticsearch13.rb
@@ -1,6 +1,6 @@
 class Elasticsearch13 < Formula
-  homepage "http://www.elasticsearch.org"
-  url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.3.9.tar.gz"
+  homepage "http://www.elastic.c://www.elastic.co/products/elasticsearch"
+  url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.3.9.tar.gz"
   sha1 "ee6013d33d6371184fae970ff8f1c2d76c0834a0"
 
   bottle do

--- a/elasticsearch14.rb
+++ b/elasticsearch14.rb
@@ -1,6 +1,6 @@
 class Elasticsearch14 < Formula
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.4.tar.gz"
+  url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.4.4.tar.gz"
   sha256 "a3158d474e68520664debaea304be22327fc7ee1f410e0bfd940747b413e8586"
 
   depends_on :java => "1.7+"


### PR DESCRIPTION
Elasticsearch have changed domain names. The old download URLs no longer work. Changing the host inside the URLs seems to make them work again.