### PR TITLE
play12 1.2.7.2

### DIFF
--- a/play12.rb
+++ b/play12.rb
@@ -1,15 +1,26 @@
-require 'formula'
-
 class Play12 < Formula
-  homepage 'http://www.playframework.org/'
-  url 'http://downloads.typesafe.com/play/1.2.7/play-1.2.7.zip'
-  sha1 '436739d9f7cc00567a7e4245413c9c1ebf886797'
+  homepage "http://www.playframework.org/"
+  url "http://downloads.typesafe.com/play/1.2.7.2/play-1.2.7.2.zip"
+  sha256 "4fc610e2db0993fee3daf01527ba5ca57a9ad970c429733415ee59b55064b322"
+
+  conflicts_with "sox", :because => "Both install a `play` executable"
 
   def install
-    rm_rf 'python' # we don't need the bundled Python for windows
-    rm Dir['*.bat']
-    libexec.install Dir['*']
-    bin.mkpath
-    ln_s libexec+'play', bin
+    rm_rf "python" # we don't need the bundled Python for windows
+    rm Dir["*.bat"]
+    libexec.install Dir["*"]
+    chmod 0755, libexec/"play"
+    bin.install_symlink libexec/"play"
+  end
+
+  test do
+    require "open3"
+    Open3.popen3("#{bin}/play new #{testpath}/app") do |stdin, _, _|
+      stdin.write "\n"
+      stdin.close
+    end
+    %W[app conf lib public test].each do |d|
+      File.directory? testpath/"app/#{d}"
+    end
   end
 end


### PR DESCRIPTION
- couldn't get the test to work with a plain `IO.popen`
- should the executable be renamed `play12` rather than introducing a conflict?