### PR TITLE
Created formula for installing Ant version 1.7.1

### DIFF
--- a/ant171.rb
+++ b/ant171.rb
@@ -1,7 +1,7 @@
 class Ant171 < Formula
   desc "Java build tool (version 1.7.1)"
   homepage "https://ant.apache.org/"
-  url "http://archive.apache.org/dist/ant/binaries/apache-ant-1.7.1-bin.tar.bz2"
+  url "https://archive.apache.org/dist/ant/binaries/apache-ant-1.7.1-bin.tar.bz2"
   sha256 "24e54c9d90b81d1b7342695a8285a969393fd883e99ffbbc04203c106d9c2f97"
   head "https://git-wip-us.apache.org/repos/asf/ant.git"
 

--- a/ant171.rb
+++ b/ant171.rb
@@ -1,0 +1,60 @@
+class Ant171 < Formula
+  desc "Java build tool (version 1.7.1)"
+  homepage "https://ant.apache.org/"
+  url "http://archive.apache.org/dist/ant/binaries/apache-ant-1.7.1-bin.tar.bz2"
+  sha256 "24e54c9d90b81d1b7342695a8285a969393fd883e99ffbbc04203c106d9c2f97"
+  head "https://git-wip-us.apache.org/repos/asf/ant.git"
+
+  option "with-ivy", "Install ivy dependency manager"
+  option "with-bcel", "Install Byte Code Engineering Library"
+
+  resource "ivy" do
+    url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
+    sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
+  end
+
+  resource "bcel" do
+    url "http://central.maven.org/maven2/org/apache/bcel/bcel/5.2/bcel-5.2.jar"
+    sha256 "7b87e2fd9ac3205a6e5ba9ef5e58a8f0ab8d1a0e0d00cb2a761951fa298cc733"
+  end
+
+  def install
+    rm Dir["bin/*.{bat,cmd,dll,exe}"]
+    libexec.install Dir["*"]
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+    if build.with? "ivy"
+      resource("ivy").stage do
+        (libexec/"lib").install Dir["ivy-*.jar"]
+      end
+    end
+    if build.with? "bcel"
+      resource("bcel").stage do
+        (libexec/"lib").install Dir["bcel-*.jar"]
+      end
+    end
+  end
+
+  test do
+    (testpath/"build.xml").write <<-EOS.undent
+      <project name="HomebrewTest" basedir=".">
+        <property name="src" location="src"/>
+        <property name="build" location="build"/>
+        <target name="init">
+          <mkdir dir="${build}"/>
+        </target>
+        <target name="compile" depends="init">
+          <javac srcdir="${src}" destdir="${build}"/>
+        </target>
+      </project>
+    EOS
+    (testpath/"src/main/java/org/homebrew/AntTest.java").write <<-EOS.undent
+      package org.homebrew;
+      public class AntTest {
+        public static void main(String[] args) {
+          System.out.println("Testing Ant with Homebrew!");
+        }
+      }
+    EOS
+    system "#{bin}/ant", "compile"
+  end
+end


### PR DESCRIPTION
Sometimes you just need an ancient version of ant and it would be great to brew install it.  Ant 1.7.x suffered from an API break in the 1.8.x series, so here is the final version of 1.7.x.