### PR TITLE
influxdb 0.8.8

### DIFF
--- a/influxdb088.rb
+++ b/influxdb088.rb
@@ -1,0 +1,83 @@
+class Influxdb088 < Formula
+  desc "Time series, events, and metrics database"
+  homepage "http://influxdb.com"
+  url "https://s3.amazonaws.com/get.influxdb.org/influxdb-0.8.8.src.tar.gz"
+  sha256 "97fb5a4ffda1b333187ebd6449466d38d864686a3bd50a6c7bfb3deeae06cfae"
+
+  depends_on "leveldb"
+  depends_on "rocksdb"
+  depends_on "autoconf" => :build
+  depends_on "protobuf" => :build
+  depends_on "bison" => :build
+  depends_on "flex" => :build
+  depends_on "go" => :build
+  depends_on "gawk" => :build
+  depends_on :hg => :build
+
+  conflicts_with "influxdb", :because => "Differing versions of the same formula"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    Dir.chdir File.join(buildpath, "src", "github.com", "influxdb", "influxdb")
+
+    flex = Formula["flex"].bin/"flex"
+    bison = Formula["bison"].bin/"bison"
+
+    inreplace "configure" do |s|
+      s.gsub! "echo -n", "$as_echo_n"
+    end
+
+    system "./configure", "--with-flex=#{flex}", "--with-bison=#{bison}", "--with-rocksdb"
+    system "make", "parser", "protobuf"
+    system "go", "build", "-tags", "leveldb rocksdb", "-o", "influxdb", "github.com/influxdb/influxdb/daemon"
+
+    inreplace "config.sample.toml" do |s|
+      s.gsub! "/tmp/influxdb/development/db", "#{var}/influxdb/data"
+      s.gsub! "/tmp/influxdb/development/raft", "#{var}/influxdb/raft"
+      s.gsub! "/tmp/influxdb/development/wal", "#{var}/influxdb/wal"
+      s.gsub! "influxdb.log", "#{var}/influxdb/logs/influxdb.log"
+    end
+
+    bin.install "influxdb" => "influxdb"
+    etc.install "config.sample.toml" => "influxdb.conf"
+
+    (var/"influxdb/data").mkpath
+    (var/"influxdb/raft").mkpath
+  end
+
+  plist_options :manual => "influxdb -config=#{HOMEBREW_PREFIX}/etc/influxdb.conf"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <dict>
+          <key>SuccessfulExit</key>
+          <false/>
+        </dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/influxdb</string>
+          <string>-config=#{etc}/influxdb.conf</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{var}</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/influxdb.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/influxdb.log</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/influxdb", "-v"
+  end
+end


### PR DESCRIPTION
Influxdb 0.9 is the latest and greatest but has api changes, and not all tooling in the ecosystem supports it.

Could we please add a 0.8.8 version?

Thanks!