### PR TITLE
Remove root_url if bintray

### DIFF
--- a/ansible14.rb
+++ b/ansible14.rb
@@ -4,7 +4,6 @@ class Ansible14 < Formula
   sha1 "09f451e6634c6e7bb5705d26b9daab6efc0407c1"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "c7098fe56be7afc0c789337aeb209a9821ae3035" => :yosemite
     sha1 "f6d35bc75e6642567c2430f6c989fe5c4991ccb7" => :mavericks
     sha1 "e060a56c76c91cc0c7d524bcd2b3fb9774d183c5" => :mountain_lion

--- a/antlr2.rb
+++ b/antlr2.rb
@@ -4,7 +4,6 @@ class Antlr2 < Formula
   sha256 "853aeb021aef7586bda29e74a6b03006bcb565a755c86b66032d8ec31b67dbb9"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "7dcc3717cb1fd192ddb3200378856b81d1ccfaeeabcb60817e6927a4c78111a9" => :yosemite
     sha256 "f70c59f788573514d6666fc20410456b584e328108af814d17422121b17278d6" => :mavericks
     sha256 "2d722d988a3352dae7b13d6344af7bf34a0301d39bd7d8b0da5e2f285a4af008" => :mountain_lion

--- a/appledoc22.rb
+++ b/appledoc22.rb
@@ -8,7 +8,6 @@ class Appledoc22 < Formula
   sha1 "a25d9ce876c4f7ee88d82b4532956d2c94b5d2e9"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     revision 1
     sha1 "e21eff6c8e1d59dda1aaaf4e052b46342c046a11" => :yosemite
     sha1 "1e21c233ab7e4ec4783f32d08b22553fa82baddf" => :mavericks

--- a/autoconf213.rb
+++ b/autoconf213.rb
@@ -5,7 +5,6 @@ class Autoconf213 < Formula
   sha256 "f0611136bee505811e9ca11ca7ac188ef5323a8e2ef19cffd3edb3cf08fd791e"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "aaca2ae48a63679a6ae88c537dd6b79500efac75389fd566afd6f108471f35a8" => :yosemite
     sha256 "7fab563545c3f6ae3b85dbfceaff1321191efba3d2d6d41da4aa71866eabad89" => :mavericks

--- a/autoconf264.rb
+++ b/autoconf264.rb
@@ -5,7 +5,6 @@ class Autoconf264 < Formula
   sha256 "a84471733f86ac2c1240a6d28b705b05a6b79c3cca8835c3712efbdf813c5eb6"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "445f91433235efd87983ce0f266cf4e6399860b2d4e233507151d540454730b2" => :yosemite
     sha256 "78da335244abe71dc42cf5d131818e3419895ab24591f0861af998e1c2dd355a" => :mavericks
     sha256 "bbe82576b19bfce25e975a7d6005adc6b6ed7d45f97e80f2c36537064be4221c" => :mountain_lion

--- a/automake112.rb
+++ b/automake112.rb
@@ -5,7 +5,6 @@ class Automake112 < Formula
   sha256 "0cbe570db487908e70af7119da85ba04f7e28656b26f717df0265ae08defd9ef"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "4a4b4d826397fc25ead3d15df1a9b6b5caa2f6b209db8d0fed649e6daa42646a" => :yosemite
     sha256 "6916c128cdfadb43ddec3efbf354f2c222be50f7256f9c98c395ef69aadaa300" => :mavericks
     sha256 "41def9cad836873c8a227da2995d43f8ca877ac42da218b83c498c5b3a751935" => :mountain_lion

--- a/bash-completion2.rb
+++ b/bash-completion2.rb
@@ -6,7 +6,6 @@ class BashCompletion2 < Formula
   revision 2
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "6f33a41b2cf3b2f7b5377fc03c3878537a97c1d71f405c24f3e2e4f91ea99d8a" => :yosemite
     sha256 "d664af0a49745230030965c62b7842c7fc94b65394b3a80f0b693e4855b59848" => :mavericks
     sha256 "40a9bbf11f9b53bb0e2d95c560eb90a793e09b62b9f85c17cbd739812fd107cf" => :mountain_lion

--- a/bind99.rb
+++ b/bind99.rb
@@ -6,7 +6,6 @@ class Bind99 < Formula
   sha1 "8a02c5e67b4d6cb49fd896bb5c56e605cac8c992"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "f6d747018fa54f5bae36b3ef9b6fae55dfd4f258" => :yosemite
     sha1 "8dd7a6d5193a39c2ceb97f03b252007cb630127f" => :mavericks
     sha1 "e595bafb76ca37fb8ea683e2b649a88e11a492f7" => :mountain_lion

--- a/bison27.rb
+++ b/bison27.rb
@@ -5,7 +5,6 @@ class Bison27 < Formula
   sha256 "08e2296b024bab8ea36f3bb3b91d071165b22afda39a17ffc8ff53ade2883431"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     revision 1
     sha256 "f0c9fbb8b8734b1fe48ee8fc7ee3b272262d2eadcc4e233231b8e8312ff1578f" => :yosemite
     sha256 "510a8e77cfdf4a0be5be12d4558dcd5bdbcf61ec6808118edcfd8bd3a34799cc" => :mavericks

--- a/boost149.rb
+++ b/boost149.rb
@@ -16,7 +16,6 @@ class Boost149 < Formula
   sha256 "dd748a7f5507a7e7af74f452e1c52a64e651ed1f7263fce438a06641d2180d3c"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "f885dbcfb802d0514d555b318f82d59293844811e4f197eae615088c8b3af442" => :yosemite
     sha256 "e2dc343ebf9c83f63d23c0a61a1e181ecf77cbdd1ce38e4568d9492c2c6bebab" => :mavericks
     sha256 "6f63a75817fca6d3da4d01588bbc6f358f55f497c9c2a8b033e04b3c4d169a9a" => :mountain_lion

--- a/boost150.rb
+++ b/boost150.rb
@@ -4,7 +4,6 @@ class Boost150 < Formula
   sha256 "c9ace2b8c81fa6703d1d17c7e478de3bc51101c5adbdeb3f6cb72cf3045a8529"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "a598ebe3edd2c549bc29f5992e6b5892b3ad92487df6f35b6f79f525ed86f7ee" => :yosemite
     sha256 "2632b8727a17f65d28290c6a6d35efd3dd547a924ea3cda6ddcb40ca06ba4899" => :mavericks

--- a/boost155.rb
+++ b/boost155.rb
@@ -60,7 +60,6 @@ class Boost155 < Formula
     end
   end
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "7ddd8eaf57ef85d2cbc5bfa04f6cac1aedfbf435cefdab2ccbf1d682c846248c" => :yosemite
     sha256 "7a33b63b1e8c4afdb877cbb45b951c1867fb09ecd73f836478140cdce1ca8291" => :mavericks

--- a/boot2docker133.rb
+++ b/boot2docker133.rb
@@ -5,7 +5,6 @@ class Boot2docker133 < Formula
   url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.3.3", :revision => "81bd2efb357cf84edb928883c0df43b1334e2860"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "b268164d3c91753992d5d9488ca83120bc3d478c90bc9d399afcdf445c767270" => :yosemite
     sha256 "06c0cb4720e6c8c74227b40fe695ccd54d29e32158b798afadaebc8f29720520" => :mavericks
     sha256 "7522d7280b9e0d2cf877e0e5ec35ca381bde400ce95b0965888ce08aa6f0e024" => :mountain_lion

--- a/boot2docker141.rb
+++ b/boot2docker141.rb
@@ -4,7 +4,6 @@ class Boot2docker141 < Formula
   head "https://github.com/boot2docker/boot2docker-cli.git"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "ad01226489b8973588e93ed7584e6cf4e86493bd" => :yosemite
     sha1 "952605852a330ebe60ea41aa723c7dd8822105f6" => :mavericks
     sha1 "60b8e61e5df4eda554e81a5fbf221c81afb12f13" => :mountain_lion

--- a/camlp5-606.rb
+++ b/camlp5-606.rb
@@ -4,7 +4,6 @@ class Camlp5606 < Formula
   sha256 "763f89ee6cde4ca063a50708c3fe252d55ea9f8037e3ae9801690411ea6180c5"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "f8bf23c6b7c2be15b75b9473dd4c877c1f507e41ee569496365a7d230a2563af" => :yosemite
     sha256 "454762aac44d7c87694b767a9d2b487385b0e1d33767060144e8b1c5ac467765" => :mavericks
     sha256 "eb0015f2273826e0907229d5d7166b1f5497795c878c701462c8b9041ab6b57e" => :mountain_lion

--- a/cloog-ppl015.rb
+++ b/cloog-ppl015.rb
@@ -5,7 +5,6 @@ class CloogPpl015 < Formula
   sha256 "7cd634d0b2b401b04096b545915ac67f883556e9a524e8e803a6bf6217a84d5f"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "e80958bc126358051c2c40ba8b12aae5fa2e55a086dd103241f7469a6812df29" => :yosemite
     sha256 "e18498773771e61e533c1521212ad4f2be43f62b5c00478c89fc52934850450f" => :mavericks

--- a/cloog018.rb
+++ b/cloog018.rb
@@ -8,7 +8,6 @@ class Cloog018 < Formula
   sha1 '85f620a26aabf6a934c44ca40a9799af0952f863'
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "2a246c9d1cac00f85866d23ac9f4270335fc69131fe1b9fd72c6e756496ed72d" => :yosemite
     sha256 "94abba0efbb32299a4a26ea1d961cac7c3fb35a5c26211578b50ef17226207ba" => :mavericks

--- a/cmake28.rb
+++ b/cmake28.rb
@@ -24,7 +24,6 @@ class Cmake28 < Formula
   sha256 "8c6574e9afabcb9fc66f463bb1f2f051958d86c85c37fccf067eb1a44a120e5e"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "83602825b72eb79a9723cba0680acaa4b022fdf8d32cdc65d9241c243ff601f5" => :yosemite
     sha256 "945c415b7f278222d79947465488f7634b8c6690f0f2cd860cd923003c433a15" => :mavericks

--- a/cmake30.rb
+++ b/cmake30.rb
@@ -24,7 +24,6 @@ class Cmake30 < Formula
   sha256 "6b4ea61eadbbd9bec0ccb383c29d1f4496eacc121ef7acf37c7a24777805693e"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "71b46be0b22a43368e8beddeb50c758d281684597bfb578c0e883151c968869f" => :yosemite
     sha256 "5cbd2d245b6bb71480ac15d901d2caa8558f4429d2535fbef662e53431679cb2" => :mavericks

--- a/cmake31.rb
+++ b/cmake31.rb
@@ -24,7 +24,6 @@ class Cmake31 < Formula
   sha256 "45f4d3fa8a2f61cc092ae461aac4cac1bab4ac6706f98274ea7f314dd315c6d0"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "48981ed06d94afe406570713f8463af08f86ed02d9a42914c4ca9f622ccb90e5" => :yosemite
     sha256 "152cbc665728e7b5004142751dc250f7bdfbc454924f6fe73d5eff7d07860a12" => :mavericks

--- a/coq83.rb
+++ b/coq83.rb
@@ -17,7 +17,6 @@ class Coq83 < Formula
   sha256 "89d185fa3e0d3620703ad4b723ef85695ce427da6235fe91d74fc22d1ffcfd5d"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "beafdfe1bc6998f86828e22d1c804a8a53b0deab63b765fd356133abc56732c4" => :yosemite
     sha256 "1843f9ec028f792a0f2768fadc6ad3c96704fdda6a276c194b91304844b8fb0d" => :mavericks
     sha256 "8ae5624dd484c4da18a1b56b25a9adec861014d86155bf7ab9977d923a7d4e4c" => :mountain_lion

--- a/cvsps2.rb
+++ b/cvsps2.rb
@@ -4,7 +4,6 @@ class Cvsps2 < Formula
   sha256 "91d3198b33463861a581686d5fcf99a5c484e7c4d819384c04fda9cafec1075a"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "b8c56242eeab6032ea45267eda778852ed8101a6403ffbe570a39040849a7292" => :yosemite
     sha256 "c28f907d790d36bdb5afdb3acccf604b8dbf10c3208ffd545e6040374fcb4988" => :mavericks

--- a/docker133.rb
+++ b/docker133.rb
@@ -5,7 +5,6 @@ class Docker133 < Formula
   url "https://github.com/docker/docker.git", :tag => "v1.3.3"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha1 "efa8a6c570d0aa167dc13451636e569378b4e13a" => :yosemite
     sha1 "339d5b573e10c456228fe0f224af63b84c8c6f91" => :mavericks

--- a/docker141.rb
+++ b/docker141.rb
@@ -3,7 +3,6 @@ class Docker141 < Formula
   url "https://github.com/docker/docker.git", :tag => "v1.4.1"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha1 "fa072be59aa298d570dcc2d2ae6c1878fd0d22a7" => :yosemite
     sha1 "74f376168a3a76064a7a586527a4de1f7a97c50f" => :mavericks

--- a/docker150.rb
+++ b/docker150.rb
@@ -5,7 +5,6 @@ class Docker150 < Formula
       :revision => "a8a31eff10544860d2188dddabdee4d727545796"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "2256ee87c0119e6103017426be424fe90c7c5a6c04db41b74c8d92878063cb4a" => :yosemite
     sha256 "b324f9255ec8cd89955a149104953c8358ced91163c52caa798802ecb39e871c" => :mavericks

--- a/doxygen1831.rb
+++ b/doxygen1831.rb
@@ -5,7 +5,6 @@ class Doxygen1831 < Formula
   sha256 "0c749f68101b6c04ccb0d9696dd37836a6ba62cd8002add275058a975ee72b55"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "64977dcd670dad96123eb960e0d3c10aabc77a54581fcd80b1d739e2944bfa66" => :yosemite
     sha256 "75ea3c6a589dee81e8ca790a9c9a17aa008be2dd8c392add690a01cf37e91a63" => :mavericks

--- a/duplicity06.rb
+++ b/duplicity06.rb
@@ -4,7 +4,6 @@ class Duplicity06 < Formula
   sha256 "ac44f44abc1c5fe775a49b77e722d238c0b3bbb105e083fd505e2dca8e2c1725"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "868c0785eec052900fa9d9689cf1694197d548a668b48e8e647f712be6cd22c3" => :yosemite
     sha256 "bda0f5173e1209caf37aa178475604a490f9b63820761fbd1d2e4ca3ed43701a" => :mavericks
     sha256 "65106c3924bb7287e2ae1ef93ce9b56bd543d8bb433a23292d708bb12e415b27" => :mountain_lion

--- a/eigen2.rb
+++ b/eigen2.rb
@@ -4,7 +4,6 @@ class Eigen2 < Formula
   sha256 "7255e856ed367ce6e6e2d4153b0e4e753c8b8d36918bf440dd34ad56aff09960"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "59cbfaafbcba0535357bb63ac0e4877d47c2a52869cd32b7d6af74b5521d81bd" => :yosemite
     sha256 "38c28e3bc3a78717584ecc83fabeeb840884273301c10311c7c274517ce75a6a" => :mavericks

--- a/elasticsearch-0.20.rb
+++ b/elasticsearch-0.20.rb
@@ -6,7 +6,6 @@ class Elasticsearch020 < Formula
   sha256 '534b9fdb2fa9031f539b19cc4cfc1345bbbb013a285a21105ca87348b96b3389'
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "03e039c3fee2e353a249dfa81949b4a0bcd8b3d71141a49f6bbc6e2273947d76" => :yosemite
     sha256 "5e1d0bf4f521ef49b1b224e26ced2dd5130bf05d67d7c5a6582e10a18839e70e" => :mavericks

--- a/elasticsearch090.rb
+++ b/elasticsearch090.rb
@@ -6,7 +6,6 @@ class Elasticsearch090 < Formula
   sha256 '82904d4c564fc893a1cfc0deb4526073900072a3f4667b995881a2ec5cdfdb43'
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "40c32b6fc4a72dfc08fc9b828f87f8752497a15bff279914edd739308139c206" => :yosemite
     sha256 "9fda4444f8f94091dfaad505ece36e1918e6cd0552619c1ba202745350deefce" => :mavericks

--- a/elasticsearch11.rb
+++ b/elasticsearch11.rb
@@ -6,7 +6,6 @@ class Elasticsearch11 < Formula
   sha256 "adcea279ff2ffbe270ae86c6b563641afa93f1f5bf2ffe33e7a7c8ac2baf9527"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "53a4ed703c6c2aa968391e30a47de3c6e17cb80cb876a923eef8ad9e8ff99142" => :yosemite
     sha256 "132f4430f98f131964f209892783990f78f191f8c09289d0c6f32a7613391e65" => :mavericks

--- a/elasticsearch12.rb
+++ b/elasticsearch12.rb
@@ -4,7 +4,6 @@ class Elasticsearch12 < Formula
   sha256 "07c298cb4dae634a2514f6022cd28533be0d86e3a2d0ad75ee6f24ff49b2e22f"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     revision 1
     sha256 "ac1cb4d7b023d175ba2b28a7564375f4170bc723bdd9edc00f6e49092ffdd2c0" => :yosemite

--- a/elasticsearch13.rb
+++ b/elasticsearch13.rb
@@ -4,7 +4,6 @@ class Elasticsearch13 < Formula
   sha256 "9b12ceba35c4a48e3e0fdc93f0676917d10acb5ee9264e9f2f9efc1a73e540bd"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     revision 1
     sha256 "d1e0206d619b86fe5b2b28ad7565bc83787ae0bcf10306810e6154772fdb0679" => :yosemite

--- a/erlang-r13.rb
+++ b/erlang-r13.rb
@@ -6,7 +6,6 @@ class ErlangR13 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "6e60e6bd0aff46d0b30365d6abe335d3ab6f235c63f6606151461eac98db2aaf" => :yosemite
     sha256 "83ff1c045b09a3e97801d98a158d2eb31567452cdb56848a0bf969fc66adafc3" => :mavericks
     sha256 "c84ff9de2082588a9a8f1a71a1435756394b128665c1926ff52a7db169e2f338" => :mountain_lion

--- a/erlang-r14.rb
+++ b/erlang-r14.rb
@@ -8,7 +8,6 @@ class ErlangR14 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "ed4bb782f85cd3a74d88cfa584715fe9461f620b3d64648e8955175485b9082a" => :yosemite
     sha256 "46cf7c0c7a081119d05172cdee2f0c68f41168a273febd623ec3bcade0f3e5ec" => :mavericks
     sha256 "6a83f8d9920adffab06d16601cad43153a138c46a4bd9b4d98aa8c19293d1342" => :mountain_lion

--- a/erlang-r15.rb
+++ b/erlang-r15.rb
@@ -6,7 +6,6 @@ class ErlangR15 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "ee8e05620de5ea113fc234268ef880a168285cdeaa018ec367dc5ff918500b75" => :yosemite
     sha256 "653639650d945f6219cb24bbbfe3792d4767ecd83170fb35afae56f651f1a043" => :mavericks
     sha256 "bd871db2f82beca53b107b3dd0385738ad2da756e73a8306a3f7f3b831a67e6c" => :mountain_lion

--- a/erlang-r16.rb
+++ b/erlang-r16.rb
@@ -5,7 +5,6 @@ class ErlangR16 < Formula
   revision 2
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "46ff2e3066bc4fdb2bca0b4cf954d6ef50c4a161301d74fe4770f7dc4c6a9acb" => :yosemite
     sha256 "9da63d7852b36d2659a8eaedadf21650430b8408692174369818df01d13fb097" => :mavericks
     sha256 "943c59a888292edafb974460671327602deda37223680d52fd96dc152c1b99c7" => :mountain_lion

--- a/gawk3.rb
+++ b/gawk3.rb
@@ -5,7 +5,6 @@ class Gawk3 < Formula
   sha256 "5dbc7b2c4c328711337c2aacd09a122c7313122262e3ff034590f014067412b4"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "1759758515e164e132faca481366230aadf1b23bd4beec9fbdb5e75046d6bdeb" => :yosemite
     sha256 "69de726a50262eb82938332505f0f55b3112423212b4a2a372b1e30a90b34eef" => :mavericks
     sha256 "88861130d66e15afafc9627fb065ab4b7b45e599bb02dd50c67aa2592da67cd0" => :mountain_lion

--- a/gcc43.rb
+++ b/gcc43.rb
@@ -25,7 +25,6 @@ class Gcc43 < Formula
   sha1 "df276018e3c664c7e6aa7ca88a180515eea61663"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "1b7ce5eff2095a1666acc03479343abe1b532eba" => :mavericks
     sha1 "f926dc13742e51eb89308feddbc97aaa048d3d51" => :mountain_lion
   end

--- a/gcc44.rb
+++ b/gcc44.rb
@@ -25,7 +25,6 @@ class Gcc44 < Formula
   sha1 "a6c834b0c2f58583da1d093de7a81a20ede9af75"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "4b45d8a3814a3a4d9c32701f532b3a943d43203a" => :mavericks
     sha1 "11c4280c78346bbab3dfaef302d5a93188a28b33" => :mountain_lion
   end

--- a/gcc45.rb
+++ b/gcc45.rb
@@ -25,7 +25,6 @@ class Gcc45 < Formula
   sha1 "cb692e6ddd1ca41f654e2ff24b1b57f09f40e211"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "1e2e710d2d20b6ba378b7b4e3d211fb482e73ff7" => :yosemite
     sha1 "16a25ceb27a579ac02209a8056a13de268a63e40" => :mavericks
     sha1 "fe4459e2e4874d4f4be687acef73fa92dd2eb821" => :mountain_lion

--- a/gcc46.rb
+++ b/gcc46.rb
@@ -25,7 +25,6 @@ class Gcc46 < Formula
   sha1 "63933a8a5cf725626585dbba993c8b0f6db1335d"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "9dcb96abaa4f6c58a7d989147f4c3fade49fdfc3" => :yosemite
     sha1 "7a695d2c558a761b5f6c6166197eb37546bfb846" => :mavericks
     sha1 "16fae71675757818526e7e73007fe5b8d8e99c7d" => :mountain_lion

--- a/gcc47.rb
+++ b/gcc47.rb
@@ -27,7 +27,6 @@ class Gcc47 < Formula
   head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_7-branch"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "777237d7a300319a7b2b83dee6f5156975aace44" => :yosemite
     sha1 "bf6f7e967f2ef84e334939695c03ebaf0ddbf62f" => :mavericks
     sha1 "b906176ebbbe42371495c5cdea6fa7f85505827e" => :mountain_lion

--- a/gcc48.rb
+++ b/gcc48.rb
@@ -27,7 +27,6 @@ class Gcc48 < Formula
   head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_8-branch"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     revision 1
     sha256 "e202b6b2110c2d472966baaf238c5225cb6f84da6a1f963ada1e0021616ec535" => :yosemite
     sha256 "6f851ed839bf11aaa0da182e30c5d2490b0500fa1f1246cd9518229dadee19d7" => :mavericks

--- a/gcc49.rb
+++ b/gcc49.rb
@@ -28,7 +28,6 @@ class Gcc49 < Formula
   head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_9-branch"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     revision 1
     sha256 "2b1284fe314224509aa629a667cd0e00b276a9c44c5fd4cecc337d47faf4dbcc" => :yosemite
     sha256 "6698beb47cbd336a31dd0a70ef1392be5233aa37d1f69b848dc29f162ddb50d2" => :mavericks

--- a/gdal111.rb
+++ b/gdal111.rb
@@ -16,7 +16,6 @@ class Gdal111 < Formula
   end
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "d08566f01643c65667522d287fa57b6bc3fb57ae64e4e3cc28d77e5d90b09f3f" => :yosemite
     sha256 "da2e1aa7e76345c2b37e30597252c3e26ac66cbc9f88a9a706cbf1a86691df9d" => :mavericks
     sha256 "ed26f48d1045fadca9eae03442470b996deb7ae6cf7ded44ded9e095bfa25544" => :mountain_lion

--- a/gecode373.rb
+++ b/gecode373.rb
@@ -4,7 +4,6 @@ class Gecode373 < Formula
   sha256 "e7cc8bcc18b49195fef0544061bdd2e484a1240923e4e85fa39e8d6bb492854c"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "dac2c21c58fb4a4f1db2d04400f2c5f4459e7e2acc03cc647bf1f97f4ea35cff" => :yosemite
     sha256 "662e1e834400151e543367376cf61e120e3074bb8b4c5843c7f036dc8678f66b" => :mavericks

--- a/giflib5.rb
+++ b/giflib5.rb
@@ -4,7 +4,6 @@ class Giflib5 < Formula
   sha256 "606d8a366b1c625ab60d62faeca807a799a2b9e88cbdf2a02bfcdf4429bf8609"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "6ed13aadad66c923b480c7c2298fd7d1857dc58c260f972fb9e28aa45e08869d" => :yosemite
     sha256 "04858ea96297f92679f93c92a37e6081b059ac0bdfce34c9eb99a4c823d746d5" => :mavericks

--- a/glfw2.rb
+++ b/glfw2.rb
@@ -4,7 +4,6 @@ class Glfw2 < Formula
   sha256 "d1f47e99e4962319f27f30d96571abcb04c1022c000de4d01df69ec59aae829d"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "e8671d6afb9e92f0aa692997a7fce65fcbd686e4e1762d4afc546542bead8211" => :yosemite
     sha256 "c13596bfe24aabf4b717f95ee6a3d8e9103b2122a614b7cc0d011d0570487ea3" => :mavericks

--- a/glfw3.rb
+++ b/glfw3.rb
@@ -4,7 +4,6 @@ class Glfw3 < Formula
   sha256 "4a8516223c1df079efb398754f4533af7e943188ea9b5222e7f27c25e4822d61"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "039df5a5929bdbdc6b20cf5fb3fffcff4d7a6360e76a2878e43152d993e7566c" => :yosemite
     sha256 "0784107860072dc0cbfc61fcf8cdd84110cb3e37a0da1e2ff4a60e4e4bbf1c6b" => :mavericks
     sha256 "e75bdc4478ee0510be626b78ff1f0862de8ff9fea26d9b4432ce2b7967c9b80c" => :mountain_lion

--- a/gmp4.rb
+++ b/gmp4.rb
@@ -8,7 +8,6 @@ class Gmp4 < Formula
   sha1 'c011e8feaf1bb89158bd55eaabd7ef8fdd101a2c'
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "40de88cbcd04d6869051eb8617afbb2e0754f680f6754708652a807349948815" => :yosemite
     sha256 "7543fa0986dfa81487367b410c178ca581560df39ca53dfc7d66e2c2a4543813" => :mavericks

--- a/gnupg21.rb
+++ b/gnupg21.rb
@@ -6,7 +6,6 @@ class Gnupg21 < Formula
   sha256 "5e599ad542199f3bd733eed2b88a539d1b4c3beda2dbab0ff69f1896f52e92fd"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "19c095a0cad8c62047701fea74815335465062e30dfbc258f1f3d867745d4b96" => :yosemite
     sha256 "9d2ca5b007020d43b26eafacb07ac8fe530d72176fc4f199faa73b92c6fa1982" => :mavericks
     sha256 "5b5d9ef88255adb89f68220a70d8627de66dcc82a1c7e8847e9d5efe8ff60c02" => :mountain_lion

--- a/gnuplot4.rb
+++ b/gnuplot4.rb
@@ -10,7 +10,6 @@ class Gnuplot4 < Formula
   sha256 "1f19596fd09045f22225afbfec11fa91b9ad1d95b9f48406362f517d4f130274"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "231af7bcc0ba62d137d2a191274bbf8030633e8612c773746ae157f0d305a624" => :yosemite
     sha256 "5489c26f250a2d45b7d14c29f047c04a526775edb0d183a580e2d6678a49dec1" => :mavericks
     sha256 "443d876966452eb42a1cf851d3d7cd4ab8c92056383f975a5c533ad4c94c9d27" => :mountain_lion

--- a/gnutls34.rb
+++ b/gnutls34.rb
@@ -6,7 +6,6 @@ class Gnutls34 < Formula
   sha256 "e9b5f58becf34756464216056cd5abbf04315eda80a374d02699dee83f80b12e"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "15ede4ba5c02fa5dcc9e7edee0ce1df29dd5acd6d5ecc57ae0eea62ae1a692ac" => :yosemite
     sha256 "387b22e785931178c6c5cf979ef19708136ed6babcd6596fcc31a39abb68a4a5" => :mavericks

--- a/go12.rb
+++ b/go12.rb
@@ -5,7 +5,6 @@ class Go12 < Formula
   sha1 "3ce0ac4db434fc1546fec074841ff40dc48c1167"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "5e138e15af3a7ac39a0b6afdc238566e25c613f9" => :yosemite
     sha1 "8ca3c757a2f30fedef50edf521f13440d787545d" => :mavericks
     sha1 "42add01f13c4a2a561a207ac5d73065759f7d253" => :mountain_lion

--- a/go13.rb
+++ b/go13.rb
@@ -5,7 +5,6 @@ class Go13 < Formula
   sha256 "1bb6fde89cfe8b9756a875af55d994cce0994861227b5dc0f268c143d91cd5ff"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "da04cd0a9ed7aba226a83abcb2bb1232592eb821cdfdc5fce3714806ea612987" => :yosemite
     sha256 "8a37cb9684cb97b5ddf0fea297aef89a8dfeca8c73cb03631aaa26fbbae20879" => :mavericks
     sha256 "8b2f2390a6b251147ba61a70b6d1be6d8ca96ea38dc0ce39290ae88ab4d0f0b8" => :mountain_lion

--- a/gsl114.rb
+++ b/gsl114.rb
@@ -5,7 +5,6 @@ class Gsl114 < Formula
   sha256 "3d4a47afd9a1e7c73b97791b4180d8cc4d5f0e5db6027fe06437f1f3f957fafb"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "e3e5dcf0d83043554296bc8dc836dcd04c496b8417bd004adab5420dc8c212b5" => :yosemite
     sha256 "5efe0db286ac52fdd72976264d1bdf1852d3d5ae6a6971a0297edc7c2f724e75" => :mavericks

--- a/gst-ffmpeg010.rb
+++ b/gst-ffmpeg010.rb
@@ -4,7 +4,6 @@ class GstFfmpeg010 < Formula
   sha256 "76fca05b08e00134e3cb92fa347507f42cbd48ddb08ed3343a912def187fbb62"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "e2b235b7fad36a8dbac8bcb4f67be0029bb875750c5dce53c288bb66a42018d5" => :yosemite
     sha256 "7dbd43f72c6053da45118caa49a27e766dd0e8107c80d6a8cd6a2c8e60de7199" => :mavericks
     sha256 "8ab9cab615859d33de819a0a314de82f8d2b70bdffea9489f7d82f57614b2ca9" => :mountain_lion

--- a/gst-plugins-bad010.rb
+++ b/gst-plugins-bad010.rb
@@ -5,7 +5,6 @@ class GstPluginsBad010 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "413d08dd42855899df225b20b391a9e7ab37da5f9d46cfbcdaeb8ad906cddb01" => :yosemite
     sha256 "24429ab0e2e44c457a914131c91fcdd5367794366593c6ed192ba1de22f5ae8b" => :mavericks
     sha256 "7265d55c630ed8de96a59257d47640cbd664ec31bfbb5f1f90413291c716b1a8" => :mountain_lion

--- a/gst-plugins-base010.rb
+++ b/gst-plugins-base010.rb
@@ -4,7 +4,6 @@ class GstPluginsBase010 < Formula
   sha256 "2cd3b0fa8e9b595db8f514ef7c2bdbcd639a0d63d154c00f8c9b609321f49976"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "a8b4f2d006de309842dba3547c64e0d8c815ab8d81786adae15e3f3c6325eab8" => :yosemite
     sha256 "5b5309d925799796c079c1c1ab21d087d055cd17a8d1b0d032781a2d121619e0" => :mavericks
     sha256 "b24984c21803c8aba964e8d79200d9125c47975a928be597e588436bd274d737" => :mountain_lion

--- a/gst-plugins-good010.rb
+++ b/gst-plugins-good010.rb
@@ -4,7 +4,6 @@ class GstPluginsGood010 < Formula
   sha256 "7e27840e40a7932ef2dc032d7201f9f41afcaf0b437daf5d1d44dc96d9e35ac6"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "9e5accf0d6347e55564baf11360870dd8ea0340323c19325fe4a728d153a8c8d" => :yosemite
     sha256 "a3deea24416800ea6bf996f9ab63233e5aeb23848d8733d77d9f1ec3a7d7a8cc" => :mavericks
     sha256 "e84402c150693fa0719230a9947449fabd3d637c8400f3ace4e0302847935304" => :mountain_lion

--- a/gst-plugins-ugly010.rb
+++ b/gst-plugins-ugly010.rb
@@ -4,7 +4,6 @@ class GstPluginsUgly010 < Formula
   sha256 "1ca90059275c0f5dca71d4d1601a8f429b7852baed0723e820703b977e2c8df0"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "d31e63e1303fa3a8111cbff9ecbd72eb6cf9ac3607f81a9cd4e6b5f08600ac04" => :yosemite
     sha256 "d0d519f2b26419bdf5aa8d51dadde2d1f89856e5213aece5399128cb2c798f6b" => :mavericks
     sha256 "b3cd3c7daa0f5c6759b9cf67b89aa48ddf451c8084565c0d3bf922b9295f4620" => :mountain_lion

--- a/gst-python010.rb
+++ b/gst-python010.rb
@@ -4,7 +4,6 @@ class GstPython010 < Formula
   sha256 "8f26f519a5bccd770864317e098e5e307fc5ad1201eb96329634b6508b253178"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "8733d920b1b69bb171774c6e399071ed58c1a2e687c612f380947d5e1fea1e83" => :yosemite
     sha256 "d526f793ea62bd1a298aecfb6a635105303a8230cd43338fde43e3b12161cebd" => :mavericks
     sha256 "13be6f9f7c40553c881363bf6a494e823bf1628b0996e4183b26e03eae652b8a" => :mountain_lion

--- a/gst-rtsp010.rb
+++ b/gst-rtsp010.rb
@@ -4,7 +4,6 @@ class GstRtsp010 < Formula
   sha256 "9915887cf8515bda87462c69738646afb715b597613edc7340477ccab63a6617"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "7ed3612a628ad6a01f44c6004ecc315125b5316ec04101a264548d10212d5b6a" => :yosemite
     sha256 "159f46f882b63c1ea06fe3d30b4a0b41a44badd233af8f911f2da51778cd16d6" => :mavericks

--- a/gstreamer010.rb
+++ b/gstreamer010.rb
@@ -4,7 +4,6 @@ class Gstreamer010 < Formula
   sha256 "e556a529e0a8cf1cd0afd0cab2af5488c9524e7c3f409de29b5d82bb41ae7a30"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "2d305985473d2ee608f04e28198b4231cba5c1086ee54bf9bbfb1e01c191aae7" => :yosemite
     sha256 "d86e6b0320b8938ddb393f1786fa97773867584d205af43ea26c383dfbe793e5" => :mavericks
     sha256 "93b0ef760f8d1a8971689ca83adb7acef0a5904fe262f537f27bbd730ed2b814" => :mountain_lion

--- a/hdf4.rb
+++ b/hdf4.rb
@@ -4,7 +4,6 @@ class Hdf4 < Formula
   sha256 "bb0e900b8cc6bc89a5730abc97e654e7705e8e1fbc4e0d4477f417822428d99b"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "8ba0e3973461d87e378cebcfef7d6d73ceb49a999e47d8c19bd083f4f9d8cacf" => :yosemite
     sha256 "7a56cd6de013df4548bc13f17cc1ff2585b24f2baf4bc8056d91a46a7ed099f7" => :mavericks
     sha256 "d0f88cadfb4fd2e5a2e7dc996d5d218531c43924812443ecad15a1393eb50388" => :mountain_lion

--- a/imagemagick-ruby186.rb
+++ b/imagemagick-ruby186.rb
@@ -4,7 +4,6 @@ class ImagemagickRuby186 < Formula
   sha256 "2330183bdecfda05f0503dcbf9cc74bc313211717194a2dbe4e3074564e9c2df"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "2dd389cdca475b1a4dbdc3e0169f87ba86b7ea6bf44c6bd2b80f551a82589d78" => :yosemite
     sha256 "f6005dc489e5c0589a6305105c62904168c1ac27b0b90e721b1d89a445f7ddcc" => :mavericks
     sha256 "897d2e94a983c980cb3deb620273bd0ca81a9c2fa1df07d6fc6b42014b4729db" => :mountain_lion

--- a/isl011.rb
+++ b/isl011.rb
@@ -8,7 +8,6 @@ class Isl011 < Formula
   sha1 'd7936929c3937e03f09b64c3c54e49422fa8ddb3'
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "9f4a6d0ff2f5cd7208a1c29c84eb6c452e6bcb7b7249b597507b1f0aad13e2ef" => :yosemite
     sha256 "c1ebc3499a91cad85af852f293fc330f5bf4b168af031d1927f2183736246ca9" => :mavericks

--- a/isl012.rb
+++ b/isl012.rb
@@ -6,7 +6,6 @@ class Isl012 < Formula
   sha256 "f4b3dbee9712850006e44f0db2103441ab3d13b406f77996d1df19ee89d11fb4"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "e043247dc75edb9579104e307039da57e6c1f0945567450224282604251b7235" => :yosemite
     sha256 "83301cbde866fb443dabf5836a74f8d568a14347d8db1c97aca3c0894db9bbef" => :mavericks

--- a/isl014.rb
+++ b/isl014.rb
@@ -6,7 +6,6 @@ class Isl014 < Formula
   sha256 "7e3c02ff52f8540f6a85534f54158968417fd676001651c8289c705bd0228f36"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "a6166d161841d901af54319a5434e955964712ae5cc19a88705d4f28669dc36b" => :yosemite
     sha256 "cbcb2862709fa87913927a3ce261ac989f650a3506abde6c9eaa4da2d58b2b53" => :mavericks

--- a/jpeg6b.rb
+++ b/jpeg6b.rb
@@ -4,7 +4,6 @@ class Jpeg6b < Formula
   sha256 "75c3ec241e9996504fe02a9ed4d12f16b74ade713972f3db9e65ce95cd27e35d"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "1c270f53c34c4183c52ad2101e7b47f5bddf6e5b431931bcc737dd76f1bd6270" => :yosemite
     sha256 "bf033c7f0bcdd1955574cf461a72633dfa9d2ce6415c6afabc00beddb287386f" => :mavericks

--- a/jpeg9.rb
+++ b/jpeg9.rb
@@ -5,7 +5,6 @@ class Jpeg9 < Formula
   version "9.0"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "9061df1faf981bb9e064d58a6a72b0339cf00b0824da8f09b911026a3740fef0" => :yosemite
     sha256 "969b3b006f8eddbd66c4d293d4732783510ed04346151497d204c1da3ad46c04" => :mavericks

--- a/json-c010.rb
+++ b/json-c010.rb
@@ -4,7 +4,6 @@ class JsonC010 < Formula
   sha256 "274fc9d47c1911fad9caab4db117e4be5d6b68c4547eab0c508d79c4768e170c"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "db1de5a842fe6f047617e8271fcff34aad75c5fc199121ffcff8eba1920d6257" => :yosemite
     sha256 "96227004581799c64d10f4020d371fa8803b93447767c918d9e2f8b2973a267f" => :mavericks

--- a/ledger26.rb
+++ b/ledger26.rb
@@ -4,7 +4,6 @@ class Ledger26 < Formula
   sha256 "d5c244343f054c413b129f14e7020b731f43afb8bdf92c6bdb702a17a2e2aa3a"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "cd0f88dbad8397bff4f40f64ab69528011998a32766e7df61165f0b937938651" => :yosemite
     sha256 "7b6c0c42ef6e02b2f51ef3c2dae21ea4d87ea200d0d6b514a80651567d554089" => :mavericks

--- a/leptonica169.rb
+++ b/leptonica169.rb
@@ -4,7 +4,6 @@ class Leptonica169 < Formula
   sha256 "3eb7669dcda7e417f399bb3698414ea523270797dfd36c59b08ef37a3fe0a72d"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "bae61b3605c495b109678205a0971dc0c30549eb9ef26ba7116899bda42bf600" => :yosemite
     sha256 "8dfdecd0322a25042c41515ea1f389294659f70dc9ad1934cd50a7216b1e50af" => :mavericks

--- a/libcouchbase1.rb
+++ b/libcouchbase1.rb
@@ -4,7 +4,6 @@ class Libcouchbase1 < Formula
   sha256 "ff86530a0fc21a2a6b719b389163a1f5172e379630b7dc91cbd2d16b5d586dc7"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "52edba8b85ce6eeeab3f78dd37c72568ad868e47b8609398686eeb48c3fa5017" => :yosemite
     sha256 "e21141ffd802673540b89ff710526803fb24f8d82e962d4b095b315ee691836d" => :mavericks

--- a/libdvdcss12.rb
+++ b/libdvdcss12.rb
@@ -4,7 +4,6 @@ class Libdvdcss12 < Formula
   sha256 "84f1bba6cfef1df87f774fceaefc8e73c4cda32e8f6700b224ad0acb5511ba2c"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "4069c609642a8db093211c5ac84146645f7423c05852f47bc64c89c741ea1f0f" => :yosemite
     sha256 "14712b601bf80411fa3c99fbf06a0617a533599c0ac5a07a98d6cc09d4305470" => :mavericks

--- a/libgee08.rb
+++ b/libgee08.rb
@@ -4,7 +4,6 @@ class Libgee08 < Formula
   sha256 "5e3707cbc1cebea86ab8865682cb28f8f80273869551c3698e396b5dc57831ea"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "71fa029e341ee653ac46ba119cbdc31a61d7477a2b5586dcb2ca1e900941e755" => :yosemite
     sha256 "43d06d6d2d2e6cd6a0c67aa054749df8de92c609fa6fc8cf95e1a049894115ca" => :mavericks

--- a/libmongoclient-legacy.rb
+++ b/libmongoclient-legacy.rb
@@ -6,7 +6,6 @@ class LibmongoclientLegacy < Formula
   head "https://github.com/mongodb/mongo-cxx-driver.git", :branch => "legacy"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "098e1f54a5ff0eefaa2f80bdb1c37792c9bfdebf49fc55f439a37143b6fa84bc" => :yosemite
     sha256 "016a9dff9e4f0d12919eb135976eba568d890476e9cfc53f95039e3e467df49f" => :mavericks
     sha256 "89f5e5dd0504b75c5d454536b0d604704c262e5791b0cc160e6a366eebcda827" => :mountain_lion

--- a/libmpc08.rb
+++ b/libmpc08.rb
@@ -8,7 +8,6 @@ class Libmpc08 < Formula
   sha1 '5ef03ca7aee134fe7dfecb6c9d048799f0810278'
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "a52eb16b2016623c7c31bdebad9a3d90b84082bcbf96e1648dce18e1e1d8dff3" => :yosemite
     sha256 "9e52d35c5ee1c1027701d012110dc18b546288fbbec113c09a8b3dacdb87bbc4" => :mavericks

--- a/libotr4.rb
+++ b/libotr4.rb
@@ -4,7 +4,6 @@ class Libotr4 < Formula
   sha256 "3f911994409898e74527730745ef35ed75c352c695a1822a677a34b2cf0293b4"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "5e123d6699df1de4ba60a54a298969abed51582f26a9dea376f2edb3f64c8f89" => :yosemite
     sha256 "4d49d2e193e6dcf5eeb60d096ffe8650dec6bd90145cfe120d6de38f37bca0bc" => :mavericks

--- a/libpng12.rb
+++ b/libpng12.rb
@@ -4,7 +4,6 @@ class Libpng12 < Formula
   sha256 "d4fb0fbf14057ad6d0319034188fc2aecddb493da8e3031b7b072ed28f510ec0"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "5dce4e061796e9ba41112b3f0dfd2ede83eff085e2c5fa19ceb5839a63867a41" => :yosemite
     sha256 "88360558925258c5d2701088de404ac253952e572ed1917f3e6281f3b04d6732" => :mavericks

--- a/libpqxx3.rb
+++ b/libpqxx3.rb
@@ -4,7 +4,6 @@ class Libpqxx3 < Formula
   sha1 "b8942164495310894cab39e5882c42f092570fc5"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha1 "4b252768206da1560e33af4baefb689f475556a8" => :yosemite
     sha1 "4b9dbfb332c12c1b8b8b16fff11a66d2b5ad9621" => :mavericks

--- a/libuv0.rb
+++ b/libuv0.rb
@@ -5,7 +5,6 @@ class Libuv0 < Formula
   head "https://github.com/libuv/libuv.git", :branch => "v0.10"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha1 "49427a8c4ba598d11867e33ff05f304f61cceab8" => :yosemite
     sha1 "eb147122bbabb9e35df0a77f795dd9899ba5320c" => :mavericks

--- a/libxml278.rb
+++ b/libxml278.rb
@@ -6,7 +6,6 @@ class Libxml278 < Formula
   sha256 "cda23bc9ebd26474ca8f3d67e7d1c4a1f1e7106364b690d822e009fdc3c417ec"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "e2afe51f87e12b0bd5f5a06803f397a0a2658ee04999a6b50569a0acd3afb4f1" => :yosemite
     sha256 "3e8e3fe83ad886f416ccd475052f68f3bfcf30be8f4bb7a3e67d8e76eadac783" => :mavericks
     sha256 "1ae08e74cf7b71d5c139db86a81f83098a4438546c70e030d3dc4552d49a404b" => :mountain_lion

--- a/llvm36.rb
+++ b/llvm36.rb
@@ -48,7 +48,6 @@ class Llvm36 < Formula
   end
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "efb032765af76776cb18312760c85ff27adc82cdf5fb3f3e2b897476ac1e95d2" => :yosemite
     sha256 "f07c9b5d6fbb30d2c3d3b5d294b6120969e161c5f66e7c612d5fbc77ddb26e60" => :mavericks
     sha256 "3e8da7b8853c6223097e6096a26e10d25ee2ee1c6f3929eac9c376aae825c01a" => :mountain_lion

--- a/log4cplus10.rb
+++ b/log4cplus10.rb
@@ -4,7 +4,6 @@ class Log4cplus10 < Formula
   sha256 "9af936fc4a25c3a59b7ae2c34ce95e08e8a705797ffe27e13272c01732649491"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "f005657c98f3eb20b038124a4ee15898de2fc5de45b0ce9d7cc23a2d58b62a64" => :yosemite
     sha256 "c1fb62f4325ca3d7c7f6aa7167bf7b821214347a5565fe4279f61f2d523254a9" => :mavericks

--- a/lua53.rb
+++ b/lua53.rb
@@ -5,7 +5,6 @@ class Lua53 < Formula
   sha256 "072767aad6cc2e62044a66e8562f51770d941e972dc1e4068ba719cd8bffac17"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "935ee966c826f97ef1d1f1fe4e355ba74d80cbfb28a23a578818def9d80387a5" => :yosemite
     sha256 "0555a1e1068de1e88f54e4f1c5797673fe7bb68a6cf8edce18207ac3e36e93e2" => :mavericks
     sha256 "3674dd17da17cec1a24168ad94f56af94c847437814d8d7828c8bbb6303ef273" => :mountain_lion

--- a/mkvtoolnix58.rb
+++ b/mkvtoolnix58.rb
@@ -4,7 +4,6 @@ class Mkvtoolnix58 < Formula
   sha256 "3c9ec7e4c035b82a35850c5ada98a29904edc44a0d1c9b900ed05d56e6274960"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "16bcf30898539320690492bdd7d48561d9633a7b127c0c1689788110eff53651" => :yosemite
     sha256 "c58a9c895e5a915c7c8de33a61392e25d40717a103032adbf53c559d75d6d7df" => :mavericks
   end

--- a/mongodb24.rb
+++ b/mongodb24.rb
@@ -4,7 +4,6 @@ class Mongodb24 < Formula
   sha256 "b239a065a1197f811a3908bdee8d535564b94f2d79da893935e38831ebbac8b3"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "004b4e3bfdb5ee0c00b5568383b5012059d057cc30248f5604afd34fd3cb8382" => :yosemite
     sha256 "c6310fd5ea6f665c1d6aec573024b729c912865fcad25ce6723a293bcde82db7" => :mavericks

--- a/mongodb26.rb
+++ b/mongodb26.rb
@@ -4,7 +4,6 @@ class Mongodb26 < Formula
   sha256 "74228a22aaf99570e706ecde20658165e3983ee8a9f327e80974f82a4e819476"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "bd5852b11ce963080a1d9ab1515cd245f664a7e7af6b8c98c6faecca0c26cf68" => :yosemite
     sha256 "cda0943fc9b5b1c82dc05dea48b412d64ca4a67e25a403870b3c0d551e5349fc" => :mavericks

--- a/mpfr2.rb
+++ b/mpfr2.rb
@@ -8,7 +8,6 @@ class Mpfr2 < Formula
   sha1 '7ca93006e38ae6e53a995af836173cf10ee7c18c'
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "b567a28e0d55497325ab97f73e302414bd66e48068c8dbb1092d453704ffe523" => :yosemite
     sha256 "3f195ad79022a35840e46f0726f623c932ad5ef72516a873615078f053867aef" => :mavericks

--- a/mysql51.rb
+++ b/mysql51.rb
@@ -5,7 +5,6 @@ class Mysql51 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     revision 1
     sha256 "d03726056870c34cdff2174fe9f4379c445f09f03fdc73322f8a0834e1c0e43f" => :yosemite
     sha256 "6b640d89f060eedfd5495afb7dee9f1a08101bcd03d578654133de6b7175730a" => :mavericks

--- a/mysql55.rb
+++ b/mysql55.rb
@@ -5,7 +5,6 @@ class Mysql55 < Formula
   sha256 "85f05b257db39e63c82ff4b5ce4e0c6d2b07560b5fc1646d47d7ae48eab3e5de"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     revision 2
     sha256 "eeacb7aba73191733f822f8e20bf19b220becca116120d3d1aeb9ec82d0d17bb" => :yosemite
     sha256 "0059b640fb7c4c02b485423e7135f0d4d30cda7c21533d16d460a9cf5deb2e87" => :mavericks

--- a/nasm21106.rb
+++ b/nasm21106.rb
@@ -5,7 +5,6 @@ class Nasm21106 < Formula
   sha256 "90f60d95a15b8a54bf34d87b9be53da89ee3d6213ea739fb2305846f4585868a"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "bd94c4827a3fbc20d9e2534414f7879f41b6d886b260ee2d0494f0fc9af1ffcb" => :yosemite
     sha256 "f8c7f1bfacddb71283e41054461063295bdcb2f16f2bdaa3eba9958993ff5bc8" => :mavericks

--- a/nettle3.rb
+++ b/nettle3.rb
@@ -5,7 +5,6 @@ class Nettle3 < Formula
   sha256 "f6859d4ec88e70805590af9862b4b8c43a2d1fc7991df0a7a711b1e7ca9fc9d3"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "e50d9eab1bbc727db7176ce14e64583e10305edf29f58478f44e81e67129f6fb" => :yosemite
     sha256 "793f30f7cb3773776ad460a6cb65c63828d2030ebc6b09596f93c6925c22e95a" => :mavericks

--- a/node04.rb
+++ b/node04.rb
@@ -5,7 +5,6 @@ class Node04 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     revision 1
     sha256 "30c8b596cf0184fd7608b5370b5e10c3adf453e899fa90dfa72215837eaf499a" => :mountain_lion
   end

--- a/node06.rb
+++ b/node06.rb
@@ -5,7 +5,6 @@ class Node06 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     revision 1
     sha256 "1cd2e47454085ccf21ca1b5a6e9366ec0f6ba0f6d7f5bd20d08f830b3df70d48" => :yosemite
     sha256 "b758f04ea1979adfe27cf6c4f161d98698d6056d8b0d1fe47071ffb702b1f81e" => :mavericks

--- a/node08.rb
+++ b/node08.rb
@@ -6,7 +6,6 @@ class Node08 < Formula
   revision 4
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "1c6f050a5a431e52f9734b081cf1986495a667e4e42d9d6813b2bc105564ee9f" => :yosemite
     sha256 "0408da3d54dc20c365c3c018d040e9aac208fa96e3f58038188bcb9793a0430d" => :mavericks
     sha256 "e9eeda21f549315674d327c595a356bd4ae06446d4cc94d0edc77aefb640e570" => :mountain_lion

--- a/objective-caml312.rb
+++ b/objective-caml312.rb
@@ -5,7 +5,6 @@ class ObjectiveCaml312 < Formula
   sha256 "edcf563da75e0b91f09765649caa98ab1535e0c7498f0737b5591b7de084958d"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "c6f0d0c36a7e45097b1c5b96ff159d6049d691828369bcef6a481bad071413eb" => :yosemite
     sha256 "2bd5864b49e5db08188649c02eea5de34799a17bc95b942d1ce5a70464d09273" => :mavericks
     sha256 "f529118355c17b749545898977a4e8e8f8ed5e72cb561e522fdf7516c0348d8a" => :mountain_lion

--- a/open-mpi16.rb
+++ b/open-mpi16.rb
@@ -4,7 +4,6 @@ class OpenMpi16 < Formula
   sha256 "fe37bab89b5ef234e0ac82dc798282c2ab08900bf564a1ec27239d3f1ad1fc85"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "62ba62c636ccf8ecedd44429b4b5289af8580c499e85d2cc54f0d3015fd7b318" => :yosemite
     sha256 "7146c0325758769fd48cba0565764c5c287eb53de8d47428e000546f51858bcb" => :mavericks
     sha256 "3d2986df69b5f759c56956ee0c94a93447ef69ed5e2bc3b42ffada4d8eacdca1" => :mountain_lion

--- a/openjpeg20.rb
+++ b/openjpeg20.rb
@@ -4,7 +4,6 @@ class Openjpeg20 < Formula
   sha256 "334df538051555381ee3bbbe3a804c9c028a021401ba2960d6f35da66bf605d8"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "652310a4988b49222c45044a009ee80a0547dc93990716d873653b3df9733b44" => :yosemite
     sha256 "d6949baa3668572dd71d6df15ac1069ee06edd3b2d8fcae255dab7d6d2f7ac2d" => :mavericks

--- a/openjpeg21.rb
+++ b/openjpeg21.rb
@@ -4,7 +4,6 @@ class Openjpeg21 < Formula
   sha256 "1232bb814fd88d8ed314c94f0bfebb03de8559583a33abbe8c64ef3fc0a8ff03"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "f40e41ca1b1ee59149411ca5054bb7aded1323f64d5b84a30ff88377d946610d" => :yosemite
     sha256 "9004d4427b26fb5d5178c5c8e942cc225d6e5e9a2439d63fb74c4022ce87544a" => :mavericks

--- a/openssl098.rb
+++ b/openssl098.rb
@@ -6,7 +6,6 @@ class Openssl098 < Formula
   sha256 "06500060639930e471050474f537fcd28ec934af92ee282d78b52460fbe8f580"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "7543cbff1b366dcbde0f554033b7531d162acd9682a0773e7b8bfbf495ef9751" => :yosemite
     sha256 "f6b0ccc6cbcbfb60ea1e960a45351497d664c4172361b1c8ccb9db657549e60a" => :mavericks
     sha256 "c832d4b68e71c13d82d064bb6a7813871d59f862dd2b7c48f5c0fa2a1ea8f2dc" => :mountain_lion

--- a/pandoc-citeproc05.rb
+++ b/pandoc-citeproc05.rb
@@ -8,7 +8,6 @@ class PandocCiteproc05 < Formula
   sha256 "83ff6d75cdf4a92d4f7fb4b7c70adcf53b30dd82831d38ad4dcb7640e9855f01"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "2bc9ccd580914bf0ab0c18489dc63d5eba688a602944c3861cea44175edd6377" => :yosemite
     sha256 "83d61ef94c02566e3d4c9441f513de774ce37221831821b579b2f1aff7efaa36" => :mavericks
     sha256 "ffdfdc0c3e02ecaa438cc4bec0c55de520dfc00bae50bda07c1a12f58bbc880f" => :mountain_lion

--- a/pandoc1131.rb
+++ b/pandoc1131.rb
@@ -8,7 +8,6 @@ class Pandoc1131 < Formula
   sha256 "7b1bb9b7d66edfbac33796a3f5d3218c2add786b95ea9dfbd497dc0e8ed27e6f"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "51316e68de6eebd7890e6d97ffc10f429b6bf1ac88a4347949a90da00f4114a5" => :yosemite
     sha256 "2a4f1c8dc251f6188413668f1c4a0f4fffc4fa4ee75555ce4c1405f7128ff351" => :mavericks
     sha256 "0befd5bd233a1a2755c3c2348b2a82234fcbbaa2f10222788fd9bd98f5a2f0d3" => :mountain_lion

--- a/percona-server55.rb
+++ b/percona-server55.rb
@@ -5,7 +5,6 @@ class PerconaServer55 < Formula
   sha1 "74610892ba6402e8df04320db444d6dcc7cb2fe8"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "4c765fa7e77cea212481b9916c140ae7eb7dac9f" => :yosemite
     sha1 "c03ce1fad24f4aa7574c291ddf28e86695d8c0d5" => :mavericks
     sha1 "1d2f86b8c062a965a28e246f9d0957855c20b883" => :mountain_lion

--- a/perl514.rb
+++ b/perl514.rb
@@ -5,7 +5,6 @@ class Perl514 < Formula
   sha256 "803fd44c492fcef79fda456a6f50455766e00ddec2e568a543630f65ff3f44cb"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "36d658ad1c0590f496b583024902136b071f217baf55e3e26704a67dc051f6c5" => :yosemite
     sha256 "abf06637a284ed6028f8795bc12eb87572992e8daf9b2d7cc9d77797dfd31f2d" => :mavericks
     sha256 "1531ddcaef9299f4951e404f3de775e9229479ae5640bd4116623c920f69f882" => :mountain_lion

--- a/perl516.rb
+++ b/perl516.rb
@@ -4,7 +4,6 @@ class Perl516 < Formula
   sha256 "69cf08dca0565cec2c5c6c2f24b87f986220462556376275e5431cc2204dedb6"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "371522e97d37ab23326a0e17786886852dcf44d98b44262fa6bb5caa0531db36" => :yosemite
     sha256 "ae94017d2adf64ce4f58e61d5c00827cacb4541f2bf9787a8a8ecd633bd0bec1" => :mavericks
     sha256 "a0fed2164f7b3718614564d7646505c3235268cc76b691506ea98426959bb9ed" => :mountain_lion

--- a/perl518.rb
+++ b/perl518.rb
@@ -4,7 +4,6 @@ class Perl518 < Formula
   sha256 "7cbed5ef11900e8f68041215eea0de5e443d53393f84c41d5c9c69c150a4982f"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "5dd29dc3db33fef36b20f65846097c6baf8b3bd52733d0de39b97dc333089a9c" => :yosemite
     sha256 "6f668e0501e54013a4dc1483aeed25b3c9ecd60976fc78b198c0e8f27d3d4842" => :mavericks
     sha256 "301f4d292b2936d97de340e691d86ad541f8dcc7eb56db8d0785df288494d194" => :mountain_lion

--- a/phantomjs198.rb
+++ b/phantomjs198.rb
@@ -4,7 +4,6 @@ class Phantomjs198 < Formula
   sha256 "3a321561677f678ca00137c47689e3379c7fe6b83f7597d2d5de187dd243f7be"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha1 "ad447564de81f1499795a6c8e2dd7b5db474f2dc" => :yosemite
     sha1 "ec47fc927a5ed38bb2c5802f661c635f6c15324d" => :mavericks

--- a/play12.rb
+++ b/play12.rb
@@ -4,7 +4,6 @@ class Play12 < Formula
   sha256 "4fc610e2db0993fee3daf01527ba5ca57a9ad970c429733415ee59b55064b322"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "cb17a08dc698a1a67715f7e84c6fe22976b5504b165caf237f608c8efc2cc33c" => :yosemite
     sha256 "dd9edaea771dde63964f647f6b49cff8714fe70598cf128a59ce59bcd4381925" => :mavericks

--- a/play13.rb
+++ b/play13.rb
@@ -4,7 +4,6 @@ class Play13 < Formula
   sha256 "9dae87f659cca29cd0144ef58491b714072ccb786eef4ccfa7741da1a2301ec0"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "341d8fb3a7d0ff51913fe9524c585560342e2705b7b291c25493125836da6890" => :yosemite
     sha256 "e745f863eac2cf9de688c5a832f9d7cd6d07fcbc67147c9135ecbd41b6276e2d" => :mavericks

--- a/postgresql8.rb
+++ b/postgresql8.rb
@@ -4,7 +4,6 @@ class Postgresql8 < Formula
   sha256 "5c1d56ce77448706d9dd03b2896af19d9ab1b9b8dcdb96c39707c74675ca3826"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "3112ea7b41cf54ef5afb870a48cadd281ad0683903f9d5a075622f471e1078c7" => :yosemite
     sha256 "5a99e0e124cc349fbf9244d470e66dae026e9b3f14c1d69bb8812eddf23dffdb" => :mavericks
     sha256 "4ac58e1036d1a0848b1642542b293c4299c44bd34b9c1aeb931a7404556b1798" => :mountain_lion

--- a/postgresql9.rb
+++ b/postgresql9.rb
@@ -5,7 +5,6 @@ class Postgresql9 < Formula
   sha256 "94d4b20d854cd7fa4c9c322c0b602751edbc5ca0d4f29fe92f996e28bb32f8a5"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "a9136942f2c992ca61b4d616edc663c134c08e1822299963a36e5df8a4cd475e" => :yosemite
     sha256 "6b36731bc9bdcf4942bcf9cd19ab7b93f3384207466e85b7f8e1145d6a1543e3" => :mavericks
     sha256 "f2bd3036934640a771d8d33e715acaa851bd3f7e0b33dc1a11f7069aac2b508d" => :mountain_lion

--- a/postgresql91.rb
+++ b/postgresql91.rb
@@ -5,7 +5,6 @@ class Postgresql91 < Formula
   sha256 "2726d526666904b454f87fe2ae54357c2ab9eb8aba299a4c904829b7598584a8"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "b835973c64ac96c1e6c2f3e32df0f920381c9533ffb369359c6bffa7f1a3f076" => :yosemite
     sha256 "711c837ee84a78f6627548ae94e7d4857e8f453de93ca92806227fa2fd50cc83" => :mavericks
     sha256 "ede5b6a722f9c46f4001cb07d88134db5cea08cfd8daeb611558820cb53ae7ab" => :mountain_lion

--- a/postgresql92.rb
+++ b/postgresql92.rb
@@ -5,7 +5,6 @@ class Postgresql92 < Formula
   sha256 "5dcbd6209a8c0f508504fa433486583a42caaa240c823e1b3576db8a72db6a44"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "40eafbdf891fd0fc0b78e9eab9eaa9cf9468a88a9c491aa81ea0dd557f509623" => :yosemite
     sha256 "27bbf8b2264982a0a1456129e66b58d5ecfb3bb25d3290f13e1295a39c6d42e4" => :mavericks
     sha256 "2af24cc10f8a6bffdf3f53b7bd9d46bed173b922846d887d840c434e1efba95b" => :mountain_lion

--- a/postgresql93.rb
+++ b/postgresql93.rb
@@ -5,7 +5,6 @@ class Postgresql93 < Formula
   sha256 "f73bd0ec2028511732430beb22414a022d2114231366e8cbe78c149793910549"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "70ea1f08bfc9b37df07074e103726a0f4ca13a28898bc849f09556b8ceca732c" => :yosemite
     sha256 "f4bd484e2bf510a2b1e1b413a79496ffd3250e501f61af87738aed827181a6ea" => :mavericks
     sha256 "a029295e7590100d8d2d902266cbffa36a2baff5014ff1515f96470c6f4cf99d" => :mountain_lion

--- a/povray36.rb
+++ b/povray36.rb
@@ -4,7 +4,6 @@ class Povray36 < Formula
   sha256 "4e8a7fecd44807343b6867e1f2440aa0e09613d6d69a7385ac48f4e5e7737a73"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "b4c715205c566890afc176085d22dc5de47aa1db8b644edfb5223ac18f4b20e9" => :yosemite
     sha256 "d2ca035fdb3a98363c038f93edc825309261019d2b329a2d13bd153f573f7a94" => :mavericks
     sha256 "0ebfed92b039a7b61606dd0639de9fadcf0eeed9ba750dd24e5e5c168492b7a4" => :mountain_lion

--- a/ppl011.rb
+++ b/ppl011.rb
@@ -7,7 +7,6 @@ class Ppl011 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "be178bf8fc11a049a27b83d0b00660a3ee4426845657f3d8279b31e10730a878" => :yosemite
     sha256 "f89fff76bdc39bea26763f765188523ba34eb9d07d3834c79a8d50a489a9aabc" => :mavericks
     sha256 "f257cca9615ae1fb0a239c1fbf4f505dbcba139744999a9c8d7f512b5dbb7fa4" => :mountain_lion

--- a/ppl10.rb
+++ b/ppl10.rb
@@ -4,7 +4,6 @@ class Ppl10 < Formula
   sha256 "fd346687482ad51c1e98eb260bd61dd5a35a0cff5f580404380c88b0089a71b4"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "12126de7c884e43d2c2dc4a334266ee950fd71abafcfee24c542c7213cb81966" => :yosemite
     sha256 "275df32f51620777164a1ee3a85316b72a884a4326c099a72951531646995b5e" => :mavericks
     sha256 "a08ca71a5cb5d3067807303e9ddbe11af4ee80ff16df0737139c13e62cd6a364" => :mountain_lion

--- a/protobuf240a.rb
+++ b/protobuf240a.rb
@@ -4,7 +4,6 @@ class Protobuf240a < Formula
   sha256 "bb20941d4958bcf2fa76fde251bb4f71463d4fe28884a015c7335894344cffcb"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "19d29ffebfeb9beab833b7e8254ad19de11afea643bab6381dd51858e6a680db" => :yosemite
     sha256 "8e6160ffa4e7d1eeb4dd293b07fe4dd5fd78b134ee5a0af6e77053a57a0ccea2" => :mavericks

--- a/protobuf241.rb
+++ b/protobuf241.rb
@@ -4,7 +4,6 @@ class Protobuf241 < Formula
   sha256 "cf8452347330834bbf9c65c2e68b5562ba10c95fa40d4f7ec0d2cb332674b0bf"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "c14c1540dace3c5b6aeb588717d207cf7a9ff1c329644bf845a6926e04d3a6b6" => :yosemite
     sha256 "cfb9af41e793e8fd82d30d8ea36c1de59dc5f332bf19fa4a7a458bc34f8e1012" => :mavericks

--- a/protobuf250.rb
+++ b/protobuf250.rb
@@ -4,7 +4,6 @@ class Protobuf250 < Formula
   sha256 "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "ee9fea383fceb77512ea1ff1e5d49f615e099df5971a4c69a9d4d83840b24e56" => :yosemite
     sha256 "1b4272b801679a59d05050af402a55a17b759409884e455f212a056ff485e653" => :mavericks

--- a/qt52.rb
+++ b/qt52.rb
@@ -4,7 +4,6 @@ class Qt52 < Formula
   sha256 "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "5704fa2d665f5185ea25012ef2dbece9ab64507a72226d1f6d5e84f0c18ba2ae" => :yosemite
     sha256 "fcaad4e34400587f5836e3ac6e7d643d8d430a738f23879de5e530ac4c77eecb" => :mavericks
     sha256 "e0e2e057186950d7163c40d358c9fba035eac766f3d0c0ec07a87821e3608fde" => :mountain_lion

--- a/raptor1.rb
+++ b/raptor1.rb
@@ -5,7 +5,6 @@ class Raptor1 < Formula
   sha256 "db3172d6f3c432623ed87d7d609161973d2f7098e3d2233d0702fbcc22cfd8ca"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "e997b1a0c4babc39ba78e49ac8fecf2f738b8557da17813171a5d717fe46c49b" => :yosemite
     sha256 "924aa949684970bc6924afaf222f2374bd28d1f50a61471685d88c2fd1638e8e" => :mavericks

--- a/redis26.rb
+++ b/redis26.rb
@@ -5,7 +5,6 @@ class Redis26 < Formula
   sha256 "5a65b54bb6deef2a8a4fabd7bd6962654a5d35787e68f732f471bbf117f4768e"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "1c0c9565f242a1e34d171950a341e2f38372e49cc5420162c73cf2c39ef2c682" => :yosemite
     sha256 "f4abb52ec0ef232b85aae9c0e3bbc6cfdfca3e43daeef38e46f3eaeb35644b45" => :mavericks

--- a/redis28.rb
+++ b/redis28.rb
@@ -4,7 +4,6 @@ class Redis28 < Formula
   sha256 "3da371693bb54c22da04d86cab1b871072c8d19bdfbc4f811469b7b53384c563"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "a116b30423226cd4445de190acd97c955962d7ae589ccac0aaf9b9585fb5dfca" => :yosemite
     sha256 "a0b72d84d805f8fec1bc1307479ba550e620fca0198746704c23b44833e3e0bd" => :mavericks

--- a/ruby182.rb
+++ b/ruby182.rb
@@ -6,7 +6,6 @@ class Ruby182 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "4e918f3ec701769e0e0ddfb459fb3d45a3072fe4732ac589496c316f73beb85d" => :yosemite
     sha256 "47684646fc21d058141fba06b3b54068ac1a852f6e1c9fc9df4b4335fcc2567d" => :mavericks
     sha256 "7791867a6be241be8af20d25727a4730040a738e66a2c21cd7046ce117be2fad" => :mountain_lion

--- a/ruby186.rb
+++ b/ruby186.rb
@@ -5,7 +5,6 @@ class Ruby186 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "e1c95c51e9e6bded398ddbdf005eb11546a030281bcadf2d921bd816dea96c55" => :yosemite
     sha256 "ca1bff8acfd1da8f093c2f4bdd0ebe7655ce485c6bffd0b069417497b2f739ae" => :mavericks
     sha256 "29cb67a3e824144a4e16304c4d84eed4ea4032b0ee24a130ff28a259556f2e81" => :mountain_lion

--- a/ruby187.rb
+++ b/ruby187.rb
@@ -4,7 +4,6 @@ class Ruby187 < Formula
   sha256 "b4e34703137f7bfb8761c4ea474f7438d6ccf440b3d35f39cc5e4d4e239c07e3"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "9169de1b6e0b913d950a0e25640d65cc707355b660f2742b8fbfa0b4001a83cc" => :yosemite
     sha256 "cc65723819e16bb61dfcac8f09cee14e559b9ed69d8461e040d65a47697ff00f" => :mavericks
     sha256 "62e380e8125f84e1e0978d44a50025c285d3a308d91ae3f1be36551ab0ec1c56" => :mountain_lion

--- a/ruby193.rb
+++ b/ruby193.rb
@@ -5,7 +5,6 @@ class Ruby193 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "331f6f131245fbd345a409ed4eddd92600465678a0b053b59b58d7beb9ea7139" => :yosemite
     sha256 "9f766d333e06d6c92eb40b4370a02fb0c54e29cff51adb4338050dc667a6c14d" => :mavericks
     sha256 "1b1df99ceae1a5c4b779bf6975c63d9f36620040a7703e7f6bb769a249cc508a" => :mountain_lion

--- a/ruby20.rb
+++ b/ruby20.rb
@@ -4,7 +4,6 @@ class Ruby20 < Formula
   sha256 "2dcdcf9900cb923a16d3662d067bc8c801997ac3e4a774775e387e883b3683e9"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "e9b01603d66cc5553ca7f9d3594fc0ce6d186aea4c85aaa1af1c241404452e39" => :yosemite
     sha256 "0e79ce291d4f661d7872f7deb1d809a419a7c6599483a422bc7787049f0cebb0" => :mavericks
     sha256 "6840f190b6a853a2fa885f24cf60b203424aa2a7eb887ab5f051848f072de30e" => :mountain_lion

--- a/ruby21.rb
+++ b/ruby21.rb
@@ -4,7 +4,6 @@ class Ruby21 < Formula
   sha256 "7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "4ea3c2a6303a1e26495d286ddd6c74c2212d710feb7fad6ce66c0ea0561bfda0" => :yosemite
     sha256 "8e8f1dbe8306a1f62e45fc686a585bc59432e2adf2d4dbbb87c0b18390eddaa5" => :mavericks
     sha256 "a150b28300ddce6e297075781a5b43b5185a2a884464071a7cd69075c7d311e4" => :mountain_lion

--- a/scala210.rb
+++ b/scala210.rb
@@ -4,7 +4,6 @@ class Scala210 < Formula
   sha256 "918daf7de186305ff3c47bd0e6b03e74d6648c5239c050687b57b8fac2f87eb2"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "1a831dd7a9262b967ecfaf8b19101e8ad7085cd84b8de1de8e3831cabc0c4a12" => :yosemite
     sha256 "ec0bfc9d38a57fe663e70270bcfbf374f3f74caea98aa9e460835e8956a71e46" => :mavericks

--- a/sonar4.rb
+++ b/sonar4.rb
@@ -4,7 +4,6 @@ class Sonar4 < Formula
   sha1 "755d93b58d8fe88f4e7e99eb11930254128bc5c1"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "e2107c08b2317a7bb0623c2362e09e1e67e42501" => :yosemite
     sha1 "9b645db49f27913c9edd85e1772e9fab85210986" => :mavericks
     sha1 "b1072a188f79703046a120ae35bc0534c5b9f2c6" => :mountain_lion

--- a/subversion16.rb
+++ b/subversion16.rb
@@ -5,7 +5,6 @@ class Subversion16 < Formula
   sha256 "214abc6b9359ea3a5fda2dee87dad110d1b33dcf888c1f8e361d69fbfa053943"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     revision 2
     sha256 "412d63fe92b65f47387d82019d6fc3182f38785726495cae185f6d2deea0cc20" => :yosemite
     sha256 "b13dd2a4574d01ef4afe26b66bb975b93249376446100f52f6f29a52376914f3" => :mavericks

--- a/subversion17.rb
+++ b/subversion17.rb
@@ -6,7 +6,6 @@ class Subversion17 < Formula
   revision 1
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     revision 2
     sha256 "a23dd79e9755459fa60c24a7fa384e9773390aacecbcf37015e65fcb13561877" => :yosemite
     sha256 "0d5c2a17b11d7382f5a3ee85283ebfb1ec181b4005e6e2e27bb920311f22d290" => :mavericks

--- a/swig2.rb
+++ b/swig2.rb
@@ -4,7 +4,6 @@ class Swig2 < Formula
   sha256 "65e13f22a60cecd7279c59882ff8ebe1ffe34078e85c602821a541817a4317f7"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "7b9a70bf790dec02a20db27083d4e951beaefb667b595d01e653d4c0208a1927" => :yosemite
     sha256 "adcb80642b175f0f522931d253c25c5eb16038eae88e7c0135e0ecacaccb5b7a" => :mavericks
     sha256 "db379c3fe24b5746772d1268f718541b5538074dec758749c201c29f08e484e0" => :mountain_lion

--- a/swig304.rb
+++ b/swig304.rb
@@ -4,7 +4,6 @@ class Swig304 < Formula
   sha1 "088b2fb1f3167703f79fb187fdb3b80513426eb1"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha1 "bc391261c3756a86e485d64eb5008805bfaaf1cb" => :yosemite
     sha1 "2e9bf66bd42ec87b09943dc0b37836d634b92228" => :mavericks
     sha1 "888f62e53a4c68143ea28fbbfe70560cbd6de868" => :mountain_lion

--- a/syncthing010.rb
+++ b/syncthing010.rb
@@ -5,7 +5,6 @@ class Syncthing010 < Formula
       :revision => "2470875d1436a1757e07bec09e388b75d5ac12c0"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "acea7eb8d47d40de31719437e9d12f74a0f76be0df97f33c5cedc07a5a6e4246" => :yosemite
     sha256 "48ce978c9eec4f574517e410527eee37189a11a0db2bcbabcef3d3b10a581672" => :mavericks

--- a/thrift090.rb
+++ b/thrift090.rb
@@ -9,7 +9,6 @@ class Thrift090 < Formula
   sha256 "71d129c49a2616069d9e7a93268cdba59518f77b3c41e763e09537cb3f3f0aac"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "dea7ccc0fb965a709abddfad87d5ecb886e0b5d2f4618622d320f259bccf7aed" => :yosemite
     sha256 "a9b9bf0bb4039b83d80b617d20f9a185b2f771c4e72284843c29253bd3fbbdcb" => :mavericks

--- a/unison232.rb
+++ b/unison232.rb
@@ -4,7 +4,6 @@ class Unison232 < Formula
   sha1 "68ea5709de4fcc2f9aef7b01b24637503b61b5ac"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha1 "fbcf4a1cd9b94f28bd21617ebbf07535a38c750d" => :yosemite
     sha1 "448d2e662a4fabd19451f42f2ea3473121f19253" => :mavericks

--- a/unison240.rb
+++ b/unison240.rb
@@ -4,7 +4,6 @@ class Unison240 < Formula
   sha256 "5a1ea828786b9602f2a42c2167c9e7643aba2c1e20066be7ce46de4779a5ca54"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "f7934fb365bb6d8267b9f10d7f42846dff6614fe517cc52d6c8eac85dc5f8e82" => :yosemite
     sha256 "68eb2b262e62fb0127c17285d98c180a644754a9ca14a60166ee15477d43c4de" => :mavericks

--- a/v8-315.rb
+++ b/v8-315.rb
@@ -5,7 +5,6 @@ class V8315 < Formula
   sha1 "0c47b3a5409d71d4fd6581520c8972f7451a87e4"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha1 "d2304e24d2fa6d6d499327d98755f4a0088d83d4" => :yosemite
     sha1 "1c3a4a0b45f0d5a706e048e80f5a497a6d2e02ec" => :mavericks

--- a/virtuoso616.rb
+++ b/virtuoso616.rb
@@ -4,7 +4,6 @@ class Virtuoso616 < Formula
   sha256 "c6bfa6817b3dad5f87577b68f4cf554d1bfbff48178a734084ac3dcbcea5a037"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     sha256 "a4d6211240c5c63acfa138dfee3b9ec3af59fe6b72f71d8ee3c2a309a5c0fe16" => :yosemite
     sha256 "ae32083a6b88ca8f2c62a41d6365455723118180920d6b5924db73452dc81519" => :mavericks
     sha256 "e912f51ff038a85144f9939bd43fbbaf7cc653fd8e12a18ff8774e5cc1e3542b" => :mountain_lion

--- a/zeromq32.rb
+++ b/zeromq32.rb
@@ -4,7 +4,6 @@ class Zeromq32 < Formula
   sha256 "09653e56a466683edb2f87ee025c4de55b8740df69481b9d7da98748f0c92124"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles-versions"
     cellar :any
     sha256 "616493db0ef76c1f55d93fa7cc3b253fe6237d06ea57cfd9d25e28c1c4823ee7" => :yosemite
     sha256 "fdaf595b9d71b5e0ff1485b938fa8ed6cd1766f8944b1d2afa790dfaae5853b1" => :mavericks


### PR DESCRIPTION
Based on the this conversation: https://github.com/Homebrew/homebrew/issues/42008

I've removed any bintray root_urls

llvm33.rb && llvm34.rb still have root_urls pointing to downloads.sf.net (Should these be removed also?)