### PR TITLE
Add formula for Selenium Server Standalone 2.45.0

### DIFF
--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -1,8 +1,9 @@
 class SeleniumServerStandalone245 < Formula
-  desc "Automates web browsers across many platforms using either Selenium RC style or WebDriver scripts"
+  desc "Control many web browsers for automated testing"
   homepage "http://seleniumhq.org/"
   url "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
   sha256 "1172dfa2d94b43bcbcd9e85c824fd714f2d1ed411b6919a22e7338879fad757b"
+
   conflicts_with "selenium-server-standalone", :because => "Differing version of core formula"
 
   def install
@@ -43,4 +44,3 @@ class SeleniumServerStandalone245 < Formula
   end
 
 end
-

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -2,6 +2,7 @@ class SeleniumServerStandalone245 < Formula
   homepage "http://seleniumhq.org/"
   url "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
   sha256 "1172dfa2d94b43bcbcd9e85c824fd714f2d1ed411b6919a22e7338879fad757b"
+  conflicts_with "selenium-server-standalone", :because => "Differing version of core formula"
 
   def install
     libexec.install "selenium-server-standalone-2.45.0.jar"

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -1,0 +1,42 @@
+class SeleniumServerStandalone < Formula
+  homepage "http://seleniumhq.org/"
+  url "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
+  sha1 "9bc872d1f364a3104257b1f8e055a342228259c3"
+
+  def install
+    libexec.install "selenium-server-standalone-#{version}.jar"
+    bin.write_jar_script libexec/"selenium-server-standalone-#{version}.jar", "selenium-server"
+  end
+
+  plist_options :manual => "selenium-server -p 4444"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <false/>
+      <key>ProgramArguments</key>
+      <array>
+        <string>/usr/bin/java</string>
+        <string>-jar</string>
+        <string>#{libexec}/selenium-server-standalone-#{version}.jar</string>
+        <string>-port</string>
+        <string>4444</string>
+      </array>
+      <key>ServiceDescription</key>
+      <string>Selenium Server</string>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/selenium-error.log</string>
+      <key>StandardOutPath</key>
+      <string>#{var}/log/selenium-output.log</string>
+    </dict>
+    </plist>
+  EOS
+  end
+end

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -1,5 +1,5 @@
 class SeleniumServerStandalone245 < Formula
-  desc "Automated Testing Browser Control"
+  desc "Automated Browser Control"
   homepage "http://seleniumhq.org/"
   url "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
   sha256 "1172dfa2d94b43bcbcd9e85c824fd714f2d1ed411b6919a22e7338879fad757b"

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -42,8 +42,5 @@ class SeleniumServerStandalone245 < Formula
   EOS
   end
 
-  test do
-    system "#{bin}/selenium-server", "-v"
-  end
 end
 

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -12,6 +12,10 @@ class SeleniumServerStandalone245 < Formula
   end
 
   plist_options :manual => "selenium-server -p 4444"
+  
+  test do 
+    # This package provides a script that doesn't have good testing options beyond running selenium.
+  end
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>
@@ -42,5 +46,4 @@ class SeleniumServerStandalone245 < Formula
     </plist>
   EOS
   end
-
 end

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -1,7 +1,7 @@
 class SeleniumServerStandalone245 < Formula
   homepage "http://seleniumhq.org/"
   url "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
-  sha1 "9bc872d1f364a3104257b1f8e055a342228259c3"
+  sha256 "1172dfa2d94b43bcbcd9e85c824fd714f2d1ed411b6919a22e7338879fad757b"
 
   def install
     libexec.install "selenium-server-standalone-2.45.0.jar"

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -1,5 +1,5 @@
 class SeleniumServerStandalone245 < Formula
-  desc "Control many web browsers for automated testing"
+  desc "Automated Testing Browser Control"
   homepage "http://seleniumhq.org/"
   url "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
   sha256 "1172dfa2d94b43bcbcd9e85c824fd714f2d1ed411b6919a22e7338879fad757b"

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -12,8 +12,8 @@ class SeleniumServerStandalone245 < Formula
   end
 
   plist_options :manual => "selenium-server -p 4444"
-  
-  test do 
+
+  test do
     # This package provides a script that doesn't have good testing options beyond running selenium.
   end
 

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -4,8 +4,8 @@ class SeleniumServerStandalone < Formula
   sha1 "9bc872d1f364a3104257b1f8e055a342228259c3"
 
   def install
-    libexec.install "selenium-server-standalone-#{version}.jar"
-    bin.write_jar_script libexec/"selenium-server-standalone-#{version}.jar", "selenium-server"
+    libexec.install "selenium-server-standalone-2.45.0.jar"
+    bin.write_jar_script libexec/"selenium-server-standalone-2.45.0.jar", "selenium-server"
   end
 
   plist_options :manual => "selenium-server -p 4444"
@@ -25,7 +25,7 @@ class SeleniumServerStandalone < Formula
       <array>
         <string>/usr/bin/java</string>
         <string>-jar</string>
-        <string>#{libexec}/selenium-server-standalone-#{version}.jar</string>
+        <string>#{libexec}/selenium-server-standalone-2.45.0.jar</string>
         <string>-port</string>
         <string>4444</string>
       </array>

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -1,4 +1,5 @@
 class SeleniumServerStandalone245 < Formula
+  desc "Automates web browsers across many platforms using either Selenium RC style or WebDriver scripts"
   homepage "http://seleniumhq.org/"
   url "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
   sha256 "1172dfa2d94b43bcbcd9e85c824fd714f2d1ed411b6919a22e7338879fad757b"

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -41,4 +41,9 @@ class SeleniumServerStandalone245 < Formula
     </plist>
   EOS
   end
+
+  test do
+    system "#{bin}/selenium-server", "-v"
+  end
 end
+

--- a/selenium-server-standalone245.rb
+++ b/selenium-server-standalone245.rb
@@ -1,4 +1,4 @@
-class SeleniumServerStandalone < Formula
+class SeleniumServerStandalone245 < Formula
   homepage "http://seleniumhq.org/"
   url "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
   sha1 "9bc872d1f364a3104257b1f8e055a342228259c3"


### PR DESCRIPTION
Selenium 2.46.0 prevents tests from running. Here is the bug:
https://github.com/SeleniumHQ/selenium/issues/631

The fix is in:
https://github.com/SeleniumHQ/selenium/commit/26bf0bc54be8cccab99f4fb2b170bb9aa8ad8030

This PR allows a rollback to 2.45.0. This could also be solved with a selenium HEAD branch, but since this is my first exploration here, I'm doing the easy thing.