### PR TITLE
Added Hadoop 2.4.0.

### DIFF
--- a/hadoop240.rb
+++ b/hadoop240.rb
@@ -1,0 +1,37 @@
+class Hadoop240 < Formula
+  desc "Framework for distributed processing of large data sets"
+  homepage 'https://hadoop.apache.org/'
+  url 'https://archive.apache.org/dist/hadoop/core/hadoop-2.4.0/hadoop-2.4.0.tar.gz'
+  sha1 'fc94bb5cb6c50a09fd9fd3ed5e134893ccdf1dbe'
+
+  depends_on :java
+
+  def install
+    rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]
+    libexec.install %w[bin sbin libexec share etc]
+    bin.write_exec_script Dir["#{libexec}/bin/*"]
+    sbin.write_exec_script Dir["#{libexec}/sbin/*"]
+    # But don't make rcc visible, it conflicts with Qt
+    (bin/"rcc").unlink
+
+    inreplace "#{libexec}/etc/hadoop/hadoop-env.sh",
+      "export JAVA_HOME=${JAVA_HOME}",
+      "export JAVA_HOME=\"$(/usr/libexec/java_home)\""
+    inreplace "#{libexec}/etc/hadoop/yarn-env.sh",
+      "# export JAVA_HOME=/home/y/libexec/jdk1.6.0/",
+      "export JAVA_HOME=\"$(/usr/libexec/java_home)\""
+    inreplace "#{libexec}/etc/hadoop/mapred-env.sh",
+      "# export JAVA_HOME=/home/y/libexec/jdk1.6.0/",
+      "export JAVA_HOME=\"$(/usr/libexec/java_home)\""
+  end
+
+  def caveats; <<-EOS.undent
+    In Hadoop's config file:
+      #{libexec}/etc/hadoop/hadoop-env.sh,
+      #{libexec}/etc/hadoop/mapred-env.sh and
+      #{libexec}/etc/hadoop/yarn-env.sh
+    $JAVA_HOME has been set to be the output of:
+      /usr/libexec/java_home
+    EOS
+  end
+end

--- a/hive0131.rb
+++ b/hive0131.rb
@@ -1,7 +1,7 @@
 class Hive0131 < Formula
   homepage "https://hive.apache.org"
   url "https://archive.apache.org/dist/hive/hive-0.13.1/apache-hive-0.13.1-bin.tar.gz"
-  sha256 "8c9fc9391375a67832db39ea3deaaa02"
+  sha256 "7085f5886fd70b774d7f2fcad86674d8ea5324d0cc7d59ba3c97495e43686c7f"
 
   # depends_on "hadoop"
   depends_on :java

--- a/hive0131.rb
+++ b/hive0131.rb
@@ -1,4 +1,4 @@
-class Hive011 < Formula
+class Hive0131 < Formula
   homepage "https://hive.apache.org"
   url "https://archive.apache.org/dist/hive/hive-0.13.1/hive-0.13.1-bin.tar.gz"
   md5 "8c9fc9391375a67832db39ea3deaaa02"

--- a/hive0131.rb
+++ b/hive0131.rb
@@ -3,7 +3,7 @@ class Hive0131 < Formula
   url "https://archive.apache.org/dist/hive/hive-0.13.1/apache-hive-0.13.1-bin.tar.gz"
   sha256 "7085f5886fd70b774d7f2fcad86674d8ea5324d0cc7d59ba3c97495e43686c7f"
 
-  # depends_on "hadoop"
+  depends_on "hadoop240"
   depends_on :java
 
   def install

--- a/hive0131.rb
+++ b/hive0131.rb
@@ -1,6 +1,6 @@
 class Hive0131 < Formula
   homepage "https://hive.apache.org"
-  url "https://archive.apache.org/dist/hive/hive-0.13.1/hive-0.13.1-bin.tar.gz"
+  url "https://archive.apache.org/dist/hive/hive-0.13.1/apache-hive-0.13.1-bin.tar.gz"
   md5 "8c9fc9391375a67832db39ea3deaaa02"
 
   # depends_on "hadoop"

--- a/hive0131.rb
+++ b/hive0131.rb
@@ -1,0 +1,25 @@
+class Hive011 < Formula
+  homepage "https://hive.apache.org"
+  url "https://archive.apache.org/dist/hive/hive-0.13.1/hive-0.13.1-bin.tar.gz"
+  md5 "8c9fc9391375a67832db39ea3deaaa02"
+
+  # depends_on "hadoop"
+  depends_on :java
+
+  def install
+    rm_f Dir["bin/*.bat"]
+    libexec.install %w[bin conf examples lib ]
+    libexec.install Dir["*.jar"]
+    bin.write_exec_script Dir["#{libexec}/bin/*"]
+  end
+
+  def caveats; <<-EOS.undent
+    Hadoop must be in your path for hive executable to work.
+    After installation, set $HIVE_HOME in your profile:
+      export HIVE_HOME=#{libexec}
+
+    You may need to set JAVA_HOME:
+      export JAVA_HOME="$(/usr/libexec/java_home)"
+    EOS
+  end
+end

--- a/hive0131.rb
+++ b/hive0131.rb
@@ -1,7 +1,7 @@
 class Hive0131 < Formula
   homepage "https://hive.apache.org"
   url "https://archive.apache.org/dist/hive/hive-0.13.1/apache-hive-0.13.1-bin.tar.gz"
-  md5 "8c9fc9391375a67832db39ea3deaaa02"
+  sha256 "8c9fc9391375a67832db39ea3deaaa02"
 
   # depends_on "hadoop"
   depends_on :java


### PR DESCRIPTION
Simple script to install old/archived version of Hadoop from archive.apache.org. Hive 2.4.0 is the LATEST version available on Amazon EMR AMIs so we cannot be the only ones that still want access to this!