### PR TITLE
gnupg21: tell gpg-agent where pinentry is

### DIFF
--- a/gnupg21.rb
+++ b/gnupg21.rb
@@ -58,6 +58,7 @@ class Gnupg21 < Formula
       --sbindir=#{bin}
       --sysconfdir=#{etc}
       --enable-symcryptrun
+      --with-pinentry-pgm=#{Formula["pinentry"].opt_bin}/pinentry
     ]
 
     args << "--with-readline=#{Formula["readline"].opt_prefix}" if build.with? "readline"


### PR DESCRIPTION
I just did a fresh install of OS X and tried installing `gnupg21` on a fresh install of Homebrew (nothing else installed) and discovered that `gpg-agent` is unable to find `pinentry` because of a missing compile-time flag, `--with-pinentry-pgm`. The `gpg-agent` formula used by previous versions of GnuPG [has this flag](https://github.com/Homebrew/homebrew/blob/80170b54ac5c4efce4b9eb2e9f4ff6427cc0de8f/Library/Formula/gpg-agent.rb#L34) (see [original issue](https://github.com/Homebrew/homebrew/issues/12382)), but it seems like it wasn't added to the `gnupg21` formula here after `gpg-agent` was moved into GnuPG 2.1. This breaks the default installation of GnuPG 2.1 on a fresh install of Homebrew and no previous GPG:

```
brew tap homebrew/versions
brew install gnupg21
```

Then, if we try to generate a key with:

```
gpg2 --gen-key
```

We get:

```
gpg (GnuPG) 2.1.8; Copyright (C) 2015 Free Software Foundation, Inc.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Note: Use "gpg2 --full-gen-key" for a full featured key generation dialog.

GnuPG needs to construct a user ID to identify your key.

Real name: John Smith
Email address: jsmith@example.com
You selected this USER-ID:
    "John Smith <jsmith@example.com>"

Change (N)ame, (E)mail, or (O)kay/(Q)uit? o
We need to generate a lot of random bytes. It is a good idea to perform
some other action (type on the keyboard, move the mouse, utilize the
disks) during the prime generation; this gives the random number
generator a better chance to gain enough entropy.
gpg: agent_genkey failed: No pinentry
Key generation failed: No pinentry
```

After re-installing Homebrew, killing the `gpg-agent` process from the attempted key generation above, and installing the fixed `gnupg21` formula:

```
killall gpg-agent
brew install gnupg21.rb
```

And trying to generate a key:

```
gpg2 --gen-key
```

It works:

```
gpg (GnuPG) 2.1.8; Copyright (C) 2015 Free Software Foundation, Inc.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Note: Use "gpg2 --full-gen-key" for a full featured key generation dialog.

GnuPG needs to construct a user ID to identify your key.

Real name: John Smith
Email address: jsmith@example.com
You selected this USER-ID:
    "John Smith <jsmith@example.com>"

Change (N)ame, (E)mail, or (O)kay/(Q)uit? o
We need to generate a lot of random bytes. It is a good idea to perform
some other action (type on the keyboard, move the mouse, utilize the
disks) during the prime generation; this gives the random number
generator a better chance to gain enough entropy.
```

Here, `pinentry` asks to create a passphrase and after creating one, the key is generated successfully:

```
We need to generate a lot of random bytes. It is a good idea to perform
some other action (type on the keyboard, move the mouse, utilize the
disks) during the prime generation; this gives the random number
generator a better chance to gain enough entropy.
gpg: key C58FB318 marked as ultimately trusted
public and secret key created and signed.

gpg: checking the trustdb
gpg: 3 marginal(s) needed, 1 complete(s) needed, PGP trust model
gpg: depth: 0  valid:   3  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 3u
gpg: next trustdb check due at 2015-10-27
pub   rsa2048/C58FB318 2015-10-03
      Key fingerprint = EEAC 8E80 73BA 727A 3CC4  9CD7 1ED7 6385 C58F B318
uid         [ultimate] John Smith <jsmith@example.com>
sub   rsa2048/43BF5513 2015-10-03
```

Note that `gpg2` will fork off a `gpg-agent` by default if one isn't already running, so there's no need to manually start one. If the user wants to specify another path to `pinentry` at runtime, they could do so by manually starting `gpg-agent` with the `--pinentry-program` option or by specifying the path in `gpg-agent.conf` (see [GnuPG Agent Options](https://www.gnupg.org/documentation/manuals/gnupg/Agent-Options.html)). Regardless, I think it should just work by default.

Also, I install Homebrew in `~/.homebrew` instead of `/usr/local` so that may be why I came across this, but it should still work with an alternative Homebrew path.