### PR TITLE
add formula for elixir 1.0

### DIFF
--- a/elixir10.rb
+++ b/elixir10.rb
@@ -1,0 +1,24 @@
+class Elixir10 < Formula
+  desc "Functional/dynamic language built on Erlang VM"
+  homepage "http://elixir-lang.org/"
+  url "https://github.com/elixir-lang/elixir/archive/v1.0.5.tar.gz"
+  sha256 "5ce5c226b3d11d751b41ad79b915b86f13f8a1b89ef3e733321d3f46ff4d81b8"
+
+  depends_on "erlang"
+
+  keg_only "Conflicts with elixir in main repository"
+
+  def install
+    system "make"
+    bin.install Dir["bin/*"] - Dir["bin/*.{bat,ps1}"]
+
+    Dir.glob("lib/*/ebin") do |path|
+      app = File.basename(File.dirname(path))
+      (lib/app).install path
+    end
+  end
+
+  test do
+    system "#{bin}/elixir", "-v"
+  end
+end


### PR DESCRIPTION
This adds the formula for `elixir10` with version `1.0.5` since homebrew is now using Elixir version `1.1.x` and some libraries still need the older version.

This is my first PR against `homebrew-versions` so please let me know if anything needs to be changed for a merge.  I ran `brew audit --scrict` and it seem to be ok.  Thanks!