### PR TITLE
gcc49: Add upstream patch to fix assembler generation with XCode 7

### DIFF
--- a/gcc49.rb
+++ b/gcc49.rb
@@ -27,19 +27,18 @@ class Gcc49 < Formula
 
   head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_9-branch"
 
-  bottle do
-    revision 1
-    sha256 "297b569c6e6992bee96c04c942d2f077665202a9464f9148fc67df358f04edf2" => :el_capitan
-    sha256 "b90f5d13eb7ac46bc4ae1af61c18b2d1889c55a8280af7205a43d73289c7b659" => :yosemite
-    sha256 "37073298a16b73d5c89ef34954cc52df2f3788d400fa6748a25516bac244306e" => :mavericks
-  end
-
   if MacOS.version >= :yosemite
     # Fixes build with Xcode 7.
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
     patch do
       url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
       sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+    end
+    # Fixes assembler generation with XCode 7
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66509
+    patch do
+      url "https://gist.githubusercontent.com/tdsmith/d248e025029add31e7aa/raw/444e292786df41346a3a1cc6267bba587408a007/gcc.diff"
+      sha256 "636b65a160ccb7417cc4ffc263fc815382f8bb895e32262205cd10d65ea7804a"
     end
   end
 


### PR DESCRIPTION
Same issue as was fixed in GCC 5.1, see: https://github.com/Homebrew/homebrew/issues/41633

Upstream bug details: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66509 

Adding the same patch that was used for GCC 5.x (as found in above Issue) works also for GCC 4.9.3, and fixes an assembler-related compilation issue I had using gcc 4.9.3 to compile a project on OSX 10.11.1 with XCode 7.1.1.

According to the GCC bugzilla link, the fix is planned to be backported into GCC 4.9.4.  But in the meantime this patch should fix assembler issues when using GCC 4.9.3 with XCode 7.