### PR TITLE
add sphinx 2.0.8

### DIFF
--- a/sphinx208.rb
+++ b/sphinx208.rb
@@ -1,0 +1,48 @@
+class Sphinx208 < Formula
+  desc "Full-text search engine server"
+  homepage "http://www.sphinxsearch.com"
+  url "http://sphinxsearch.com/files/sphinx-2.0.8-release.tar.gz"
+  sha256 "bd699bf34635558e4d9d4d8bdcf5fcdd9c2e8f6c614824bec793b0010fa6cda3"
+
+  option "with-mysql", "Force compiling against MySQL"
+  option "with-postgresql", "Force compiling against PostgreSQL"
+
+  depends_on :mysql => :optional
+  depends_on :postgresql => :optional
+
+  conflicts_with "sphinx", :because => "differing version of same formula"
+
+  def install
+    args = %W[--prefix=#{prefix}
+              --disable-dependency-tracking
+              --localstatedir=#{var}]
+
+    args << "--#{build.with?("mysql") ? "with" : "without"}-mysql"
+    args << "--#{build.with?("postgresql") ? "with" : "without"}-pgsql"
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  def caveats; <<-EOS.undent
+    Sphinx depends on either MySQL or PostreSQL as a datasource.
+
+    You can install these with Homebrew with:
+      brew install mysql
+        For MySQL server.
+
+      brew install mysql-connector-c
+        For MySQL client libraries only.
+
+      brew install postgresql
+        For PostgreSQL server.
+
+    We don't install these for you when you install this formula, as
+    we don't know which datasource you intend to use.
+    EOS
+  end
+
+  test do
+    assert_match /#{version}/, shell_output("#{bin}/searchd -h")
+  end
+end


### PR DESCRIPTION
# Overview
Newer versions of [sphinx](http://www.sphinxsearch.com) have a different API, which breaks compatibility with software dependent on it.

The test is basic, because a more thorough one would require installing at least `mysql` or `postgresql` as the backing store, plus a client library to actually query sphinx. (Note that the included `search` tool was not intended for production use and is [known-bad](http://sphinxsearch.com/bugs/view.php?id=1424) in this version of sphinx.)

# Thanks and reference
This is a modified version of PR #539. Thanks to @shosti for the [original code](https://github.com/shosti/homebrew-versions/blob/b7c09538a91a7dc13937be26a94067de5e05711f/sphinx208.rb).
A copy of this formula is in https://github.com/chaimleib/homebrew-formulae, where it has been tested by many users.