### PR TITLE
Set log paths for elasticsearch17

### DIFF
--- a/elasticsearch17.rb
+++ b/elasticsearch17.rb
@@ -98,9 +98,9 @@ class Elasticsearch17 < Formula
           <key>WorkingDirectory</key>
           <string>#{var}</string>
           <key>StandardErrorPath</key>
-          <string>#{prefix}/var/log/elasticsearch17.log</string>
+          <string>#{var}/log/elasticsearch17.log</string>
           <key>StandardOutPath</key>
-          <string>#{prefix}/var/log/elasticsearch17.log</string>
+          <string>#{var}/log/elasticsearch17.log</string>
         </dict>
       </plist>
     EOS

--- a/elasticsearch17.rb
+++ b/elasticsearch17.rb
@@ -98,9 +98,9 @@ class Elasticsearch17 < Formula
           <key>WorkingDirectory</key>
           <string>#{var}</string>
           <key>StandardErrorPath</key>
-          <string>/dev/null</string>
+          <string>#{prefix}/var/log/elasticsearch17.log</string>
           <key>StandardOutPath</key>
-          <string>/dev/null</string>
+          <string>#{prefix}/var/log/elasticsearch17.log</string>
         </dict>
       </plist>
     EOS


### PR DESCRIPTION
Do not use `/dev/null` for log paths. Hard to debug.