### PR TITLE
ack-1.96.rb: add ack 1.96 to homebrew-versions

### DIFF
--- a/ack-1.96.rb
+++ b/ack-1.96.rb
@@ -1,0 +1,20 @@
+require 'formula'
+
+class Ack196 < Formula
+  homepage 'http://beyondgrep.com/'
+  url 'https://github.com/petdance/ack/archive/1.96.tar.gz'
+  sha1 '5d53b2b6f285e222a8459730495d6b07c692edd6'
+
+  def install
+    system 'pod2man', 'ack', 'ack.1'
+    man1.install 'ack.1'
+    bin.install 'ack'
+    bash_completion.install 'etc/ack.bash_completion.sh'
+    zsh_completion.install 'etc/ack.zsh_completion' => '_ack'
+  end
+
+  test do
+    system "#{bin}/ack", 'brew', '/usr/share/dict/words'
+  end
+end
+


### PR DESCRIPTION
Ack 1.96 is very helpful for people who have existing configurations which are used on large numbers of machines, where Ack 2.x is not always present. In addition Ack 2.x has introduced certain bugs which were not present in Ack 1.96. Therefore nominating this port for inclusion in `homebrew-versions`.