### PR TITLE
kibana43: keep plugins alongside keg

### DIFF
--- a/kibana43.rb
+++ b/kibana43.rb
@@ -3,6 +3,7 @@ class Kibana43 < Formula
   homepage "https://www.elastic.co/products/kibana"
   url "https://github.com/elastic/kibana.git", :tag => "v4.3.1", :revision => "d6e412dc2fa54666bf6ceb54a197508a4bc70baf"
   head "https://github.com/elastic/kibana.git"
+  revision 1
 
   bottle do
     sha256 "8aa5164a2f966fa3e2a971ce67b9dbd9d2c6bf382ce20e9faae8d1b67e768cb6" => :el_capitan
@@ -64,16 +65,16 @@ class Kibana43 < Formula
 
   def post_install
     ln_s etc/"kibana", prefix/"config"
-
-    (var/"lib/kibana/installedPlugins").mkpath
-    ln_s var/"lib/kibana/installedPlugins", prefix/"installedPlugins"
+    (prefix/"installedPlugins").mkdir
   end
 
   plist_options :manual => "kibana"
 
   def caveats; <<-EOS.undent
-    Plugins: #{var}/kibana/installedPlugins/
     Config: #{etc}/kibana/
+     If you wish to preserve your plugins upon upgrade, make a copy of
+     #{prefix}/installedPlugins before upgrading, and copy it into the
+     new keg location after upgrading.
     EOS
   end
 


### PR DESCRIPTION
This commit modifies the Kibana43 formula to keep the installedPlugins
directory alongside the Kibana43 keg. This is to address an issue for
plugins that are implicitly depending on node modules from Kibana.

Relates Homebrew/homebrew#48951