### PR TITLE
mysql 5.6.29

### DIFF
--- a/mysql56.rb
+++ b/mysql56.rb
@@ -1,8 +1,8 @@
 class Mysql56 < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
-  url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.27.tar.gz"
-  sha256 "8356bba23f3f6c0c2d4806110c41d1c4d6a4b9c50825e11c5be4bbee2b20b71d"
+  url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.29.tar.gz"
+  sha256 "6ac85b75b2dfa8c232725dda25469df37bf4e48b408cc0978d0dfc34c25a817f"
 
   bottle do
     sha256 "b2d6eea1c69123f013eb8aecf0947e6c5ee2e13478bc178ec0858754a062bb38" => :el_capitan


### PR DESCRIPTION
mysql-5.6.27 has been replaced with mysql-5.6.29. Upgraded mysql5.6.rb to reflect new distribution.

Error log:
brew install https://raw.githubusercontent.com/Homebrew/homebrew-versions/master/mysql56.rb
######################################################################## 100.0%
==> Downloading https://homebrew.bintray.com/bottles/mysql56-5.6.27.yosemite.bottle.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "mysql56"
Download failed: https://homebrew.bintray.com/bottles/mysql56-5.6.27.yosemite.bottle.tar.gz
Warning: Bottle installation failed: building from source.
==> Installing dependencies for mysql56: cmake
==> Installing mysql56 dependency: cmake
==> Downloading https://homebrew.bintray.com/bottles/cmake-3.4.3.yosemite.bottle.tar.gz
######################################################################## 100.0%
==> Pouring cmake-3.4.3.yosemite.bottle.tar.gz
==> Caveats
Emacs Lisp files have been installed to:
  /usr/local/share/emacs/site-lisp/cmake
==> Summary
🍺  /usr/local/Cellar/cmake/3.4.3: 1,980 files, 27.4M
==> Downloading https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.27.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "mysql56"
Download failed: https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.27.tar.gz