### PR TITLE
add libevent 2.1.5-beta, this version is latest version of libevent.

### DIFF
--- a/libevent215b.rb
+++ b/libevent215b.rb
@@ -1,0 +1,70 @@
+class Libevent215b < Formula
+  desc "Asynchronous event library"
+  homepage "http://libevent.org"
+  url "https://github.com/libevent/libevent/releases/download/release-2.1.5-beta/libevent-2.1.5-beta.tar.gz"
+  sha256 "79e1b82236a02f1432b6d95ef94186915790eb9910211647f9c01a85149066d8"
+
+  conflicts_with "libevent", :because => "Differing versions of the same formula"
+
+  head do
+    url "https://github.com/libevent/libevent.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  depends_on "doxygen" => [:optional, :build]
+  depends_on "pkg-config" => :build
+  depends_on "openssl"
+
+  option :universal
+  option "with-doxygen", "Build and install the manpages (using Doxygen)"
+
+  deprecated_option "enable-manpages" => "with-doxygen"
+
+  fails_with :llvm do
+    build 2326
+    cause "Undefined symbol '_current_base' reported during linking."
+  end
+
+  conflicts_with "pincaster",
+    :because => "both install `event_rpcgen.py` binaries"
+
+  def install
+    ENV.universal_binary if build.universal?
+    ENV.j1
+
+    if build.with? "doxygen"
+      inreplace "Doxyfile", /GENERATE_MAN\s*=\s*NO/, "GENERATE_MAN = YES"
+    end
+
+    system "./autogen.sh" if build.head?
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-debug-mode",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+
+    if build.with? "doxygen"
+      system "make", "doxygen"
+      man3.install Dir["doxygen/man/man3/*.3"]
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <event2/event.h>
+
+      int main()
+      {
+        struct event_base *base;
+        base = event_base_new();
+        event_base_free(base);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-levent", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
Because there is no 2.1.x stable version, and it has been released over one year, so it's the only choice of stable version of 2.1.x.