### PR TITLE
Add Solr 5 recipe

### DIFF
--- a/solr5.rb
+++ b/solr5.rb
@@ -1,0 +1,65 @@
+class Solr5 < Formula
+  desc "Enterprise search platform from the Apache Lucene project"
+  homepage "https://lucene.apache.org/solr/"
+  url "https://www.apache.org/dyn/closer.cgi?path=lucene/solr/5.5.0/solr-5.5.0.tgz"
+  mirror "https://archive.apache.org/dist/lucene/solr/5.5.0/solr-5.5.0.tgz"
+  sha256 "c5fa5cb996fe1432e09bb2f6053ffbeb095436db4a77e9c6488b531db726b04d"
+
+  bottle :unneeded
+
+  depends_on :java
+
+  conflicts_with "solr", :because => "Differing versions of same formula"
+
+  skip_clean "example/logs"
+
+  def install
+    libexec.install Dir["*"]
+    bin.install "#{libexec}/bin/solr"
+    bin.install "#{libexec}/bin/post"
+    bin.install "#{libexec}/bin/oom_solr.sh"
+    share.install "#{libexec}/bin/solr.in.sh"
+    prefix.install "#{libexec}/example"
+    prefix.install "#{libexec}/server"
+
+    # Fix the classpath for the post tool
+    inreplace "#{bin}/post", '"$SOLR_TIP/dist"', "#{libexec}/dist"
+
+    # Fix the paths in the sample solrconfig.xml files
+    Dir.glob(["#{prefix}/example/**/solrconfig.xml",
+      "#{prefix}/**/data_driven_schema_configs/**/solrconfig.xml",
+      "#{prefix}/**/sample_techproducts_configs/**/solrconfig.xml"]) do |f|
+      inreplace f, ":../../../..}/", "}/libexec/"
+    end
+  end
+
+  plist_options :manual => "solr start"
+
+  def plist; <<-EOS.undent
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{opt_bin}/solr</string>
+            <string>start</string>
+            <string>-f</string>
+          </array>
+          <key>ServiceDescription</key>
+          <string>#{name}</string>
+          <key>WorkingDirectory</key>
+          <string>#{HOMEBREW_PREFIX}</string>
+          <key>RunAtLoad</key>
+          <true/>
+      </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    system bin/"solr"
+  end
+end


### PR DESCRIPTION
Which installs Solr 5.5 now that Solr 6 is released.

See also https://github.com/Homebrew/homebrew-core/pull/540