### PR TITLE
Add Apache Thrift 0.9.2 recipe

### DIFF
--- a/thrift092.rb
+++ b/thrift092.rb
@@ -1,0 +1,97 @@
+# This is the 0.9.2 version of the thrift formula and is identical
+# to the current 0.9.3 version besides the url and hash
+class Thrift092 < Formula
+  desc "Framework for scalable cross-language services development"
+  homepage "https://thrift.apache.org"
+
+  stable do
+    url "https://www.apache.org/dyn/closer.cgi?path=/thrift/0.9.2/thrift-0.9.2.tar.gz"
+    sha256 "cef50d3934c41db5fa7724440cc6f10a732e7a77fe979b98c23ce45725349570"
+
+    # Apply any necessary patches (none currently required)
+    [
+      # Example patch:
+      #
+      # Apply THRIFT-2201 fix from master to 0.9.1 branch (required for clang to compile with C++11 support)
+      # %w{836d95f9f00be73c6936d407977796181d1a506c f8e14cbae1810ade4eab49d91e351459b055c81dba144c1ca3c5d6f4fe440925},
+    ].each do |name, sha|
+      patch do
+        url "https://git-wip-us.apache.org/repos/asf?p=thrift.git;a=commitdiff_plain;h=#{name}"
+        sha256 sha
+      end
+    end
+  end
+
+  bottle do
+    cellar :any
+    revision 2
+    sha256 "4e6e392c6f93344c3f059c3967623aed6f5ea61fd44aaffb9b842c6a9aa033be" => :el_capitan
+    sha256 "17c50eb2509a29e78f2e0bd402d015de4ea847c7173073e6829fef4daaf23123" => :yosemite
+    sha256 "23829d79de301162576c53e51d16789dfa0584936b44bef8aa5cae2ff754aba7" => :mavericks
+  end
+
+  head do
+    url "https://git-wip-us.apache.org/repos/asf/thrift.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+    depends_on "pkg-config" => :build
+  end
+
+  option "with-haskell", "Install Haskell binding"
+  option "with-erlang", "Install Erlang binding"
+  option "with-java", "Install Java binding"
+  option "with-perl", "Install Perl binding"
+  option "with-php", "Install PHP binding"
+  option "with-libevent", "Install nonblocking server libraries"
+
+  depends_on "bison" => :build
+  depends_on "boost"
+  depends_on "openssl"
+  depends_on "libevent" => :optional
+  depends_on :python => :optional
+
+  conflicts_with "thrift", :because => "Differing versions of same formula"
+
+  def install
+    system "./bootstrap.sh" unless build.stable?
+
+    exclusions = ["--without-ruby", "--disable-tests", "--without-php_extension"]
+
+    exclusions << "--without-python" if build.without? "python"
+    exclusions << "--without-haskell" if build.without? "haskell"
+    exclusions << "--without-java" if build.without? "java"
+    exclusions << "--without-perl" if build.without? "perl"
+    exclusions << "--without-php" if build.without? "php"
+    exclusions << "--without-erlang" if build.without? "erlang"
+
+    ENV.cxx11 if MacOS.version >= :mavericks && ENV.compiler == :clang
+
+    # Don't install extensions to /usr:
+    ENV["PY_PREFIX"] = prefix
+    ENV["PHP_PREFIX"] = prefix
+
+    system "./configure", "--disable-debug",
+                          "--prefix=#{prefix}",
+                          "--libdir=#{lib}",
+                          *exclusions
+    ENV.j1
+    system "make"
+    system "make", "install"
+  end
+
+  def caveats; <<-EOS.undent
+    To install Ruby binding:
+      gem install thrift
+
+    To install PHP extension for e.g. PHP 5.5:
+      brew install homebrew/php/php55-thrift
+  EOS
+  end
+
+  test do
+    system "thrift", "-r", "--gen", "java", "tutorial/tutorial.thrift"
+    Dir.chdir("gen-java")
+  end
+end


### PR DESCRIPTION
Needed specific 0.9.2 version of Thrift. Only change from the brew core version of thrift is the url & sha256 hash + I added a test for homebrew audit and set to conflict with the main thrift version.