### PR TITLE
Add Liquigraph recipe (v2.0.0)

### DIFF
--- a/liquigraph200.rb
+++ b/liquigraph200.rb
@@ -1,0 +1,38 @@
+class Liquigraph200 < Formula
+  desc "Migration runner for Neo4j"
+  homepage "http://www.liquigraph.org"
+  url "https://github.com/fbiville/liquigraph/archive/liquigraph-2.0.0.tar.gz"
+  sha256 "2c9232aa4db0d8724733643b6a919910899d8e9d49965bf48dbda044c9a00021"
+  head "https://github.com/fbiville/liquigraph.git"
+
+  depends_on "maven" => :build
+  depends_on :java => "1.7+"
+
+  def install
+    ENV.java_cache
+    system "mvn", "-q", "clean", "package", "-DskipTests"
+    (buildpath/"binaries").mkpath
+    system "tar", "xzf", "liquigraph-cli/target/liquigraph-cli-bin.tar.gz", "-C", "binaries"
+    libexec.install "binaries/liquigraph-cli/liquigraph.sh" => "liquigraph"
+    libexec.install "binaries/liquigraph-cli/liquigraph-cli.jar"
+    bin.install_symlink libexec/"liquigraph"
+  end
+
+  test do
+    failing_hostname = "verrryyyy_unlikely_host"
+    changelog = (testpath/"changelog")
+    changelog.write <<-EOS.undent
+      <?xml version="1.0" encoding="UTF-8"?>
+      <changelog>
+          <changeset id="hello-world" author="you">
+              <query>CREATE (n:Sentence {text:'Hello monde!'}) RETURN n</query>
+          </changeset>
+          <changeset id="hello-world-fixed" author="you">
+              <query>MATCH (n:Sentence {text:'Hello monde!'}) SET n.text='Hello world!' RETURN n</query>
+          </changeset>
+      </changelog>
+      EOS
+    assert_match(/UnknownHostException: #{failing_hostname}/,
+      shell_output("#{bin}/liquigraph -c #{changelog.realpath} -g jdbc:neo4j://#{failing_hostname}:7474/ 2>&1", 1))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-versions/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
- [x] Does your submission adhere to Versions "Acceptable Formulae" [guidelines](https://github.com/Homebrew/homebrew-versions/blob/07b17dfb9f1/README.md#acceptable-formulae)?

---

I have two parallel versions of Liquigraph (feature-wise, they're equivalent):
- Liquigraph 2.0.0 works with Neo4j 2.x (this PR)
- Liquigraph 3.0.0 works with Neo4j 3.x ([PR against main repo](https://github.com/Homebrew/homebrew-core/pull/509))

I need to have both versions available to users so they can pick the one that suits their setup. It seems I have to pick a default, that's why I went with `3.0.0` in the main repo.
