### PR TITLE
Update URL for PhantomJS 1.9.2

### DIFF
--- a/phantomjs192.rb
+++ b/phantomjs192.rb
@@ -1,6 +1,6 @@
 class Phantomjs192 < Formula
   homepage "http://www.phantomjs.org/"
-  url "https://phantomjs.googlecode.com/files/phantomjs-1.9.2-macosx.zip"
+  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/phantomjs/phantomjs-1.9.2-macosx.zip"
   sha256 "85a1ddc5c5acb630abbfdc10617b5b248856d400218a9ec14872c7e1afef6698"
 
   depends_on :macos => :snow_leopard


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-versions/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)? **audit reports missing test, description, etc. but these omissions predate this change**
- [x] Does your submission adhere to Versions "Acceptable Formulae" [guidelines](https://github.com/Homebrew/homebrew-versions/blob/07b17dfb9f1/README.md#acceptable-formulae)? **NB older than -2 versions but update to an existing formula**

-----

The previous URL for PhantomJS 1.9.2 now returns a 404. From looking at https://code.google.com/archive/p/phantomjs/downloads this appears to be the correct new URL.