### PR TITLE
Add gradle version-2.14.1 

### DIFF
--- a/gradle2.14.1.rb
+++ b/gradle2.14.1.rb
@@ -1,0 +1,19 @@
+class Gradle21401 < Formula
+  desc "Gradle build automation tool"
+  homepage "https://www.gradle.org/"
+  url "https://downloads.gradle.org/distributions/gradle-2.14.1-bin.zip"
+  sha256 "cfc61eda71f2d12a572822644ce13d2919407595c2aec3e3566d2aab6f97ef39"
+
+  bottle :unneeded
+
+  conflicts_with "gradle", because: "Differing version of same formula"
+
+  def install
+    libexec.install %w[bin lib]
+    bin.install_symlink libexec+"bin/gradle"
+  end
+
+  test do
+    system "#{bin}/gradle", "-version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-versions/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
- [x] Does your submission adhere to Versions "Acceptable Formulae" [guidelines](https://github.com/Homebrew/homebrew-versions/blob/07b17dfb9f1/README.md#acceptable-formulae)?

-----

I wish to fetch a historic version of gradle by brew, and I have to add gradle2.14.1.rb for my purpose.
