### PR TITLE
lua53: fix standard backwards compatible bit32 operations

### DIFF
--- a/lua53.rb
+++ b/lua53.rb
@@ -36,7 +36,7 @@ class Lua53 < Formula
     # Use our CC/CFLAGS to compile.
     inreplace "src/Makefile" do |s|
       s.remove_make_var! "CC"
-      s.change_make_var! "CFLAGS", "#{ENV.cflags} -DLUA_COMPAT_ALL $(SYSCFLAGS) $(MYCFLAGS)"
+      s.change_make_var! "CFLAGS", "#{ENV.cflags} -DLUA_COMPAT_5_2 $(SYSCFLAGS) $(MYCFLAGS)"
       s.change_make_var! "MYLDFLAGS", ENV.ldflags
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-versions/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
- [x] Does your submission adhere to Versions "Acceptable Formulae" [guidelines](https://github.com/Homebrew/homebrew-versions/blob/07b17dfb9f1/README.md#acceptable-formulae)?

-----

* lua53.rb (Lua53): Upstream replaced LUA_COMPAT_ALL define from
earlier releases with LUA_COMPAT_5_2, the latter of which is needed
for luarocks to correctly intuit the presence of bit32 operations
in core when resolving rock dependencies.