### PR TITLE
cmake30 and cmake31: cleanup

### DIFF
--- a/cmake30.rb
+++ b/cmake30.rb
@@ -33,11 +33,14 @@ class Cmake30 < Formula
 
   option "without-docs", "Don't build man pages"
   depends_on :python => :build if MacOS.version <= :snow_leopard && build.with?("docs")
-
-  depends_on "qt" => :optional
+  depends_on NoExpatFramework
 
   conflicts_with "cmake", :because => "both install a cmake binary"
   conflicts_with "cmake31", :because => "both install a cmake binary"
+
+  # The `with-qt` GUI option was removed due to circular dependencies if
+  # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
+  # For the GUI application please instead use brew install caskroom/cask/cmake.
 
   resource "sphinx" do
     url "https://pypi.python.org/packages/source/S/Sphinx/Sphinx-1.2.3.tar.gz"
@@ -63,8 +66,6 @@ class Cmake30 < Formula
     url "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz"
     sha256 "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3"
   end
-
-  depends_on NoExpatFramework
 
   def install
     if build.with? "docs"
@@ -93,12 +94,9 @@ class Cmake30 < Formula
       args << "--sphinx-man" << "--sphinx-build=#{buildpath}/sphinx/bin/sphinx-build"
     end
 
-    args << "--qt-gui" if build.with? "qt"
-
     system "./bootstrap", *args
     system "make"
     system "make", "install"
-    bin.install_symlink Dir["#{prefix}/CMake.app/Contents/bin/*"] if build.with? "qt"
   end
 
   test do

--- a/cmake31.rb
+++ b/cmake31.rb
@@ -35,6 +35,7 @@ class Cmake31 < Formula
 
   depends_on :python => :build if MacOS.version <= :snow_leopard && build.with?("docs")
   depends_on "xz" # For LZMA
+  depends_on NoExpatFramework
 
   conflicts_with "cmake", :because => "both install a cmake binary"
   conflicts_with "cmake30", :because => "both install a cmake binary"
@@ -67,8 +68,6 @@ class Cmake31 < Formula
     url "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz"
     sha256 "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3"
   end
-
-  depends_on NoExpatFramework
 
   def install
     if build.with? "docs"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-versions/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
- [ ] Does your submission adhere to Versions "Acceptable Formulae" [guidelines](https://github.com/Homebrew/homebrew-versions/blob/master/README.md#acceptable-formulae)?

-----

Move the depends to the top for both formulae as asked by brew audit
Removed qt dependency, which is already gone for cmake31 and the
latest cmake in core.
See also homebrew-core commit e427965e4ba95007de0a47679bd09f13fef2178d