### PR TITLE
protobuf260: Fix formula to include missing __init__.py

### DIFF
--- a/protobuf260.rb
+++ b/protobuf260.rb
@@ -91,6 +91,8 @@ class Protobuf260 < Formula
       site_packages = "lib/python2.7/site-packages"
       pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
       (prefix/site_packages/"homebrew-protobuf.pth").write pth_contents
+      # pyext init is missing from the 2.6 protobuf package
+      touch libexec/site_packages/"google/protobuf/pyext/__init__.py"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-versions/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
- [x] Does your submission adhere to Versions "Acceptable Formulae" [guidelines](https://github.com/Homebrew/homebrew-versions/blob/master/README.md#acceptable-formulae)?

-----
