### PR TITLE
tap_migrations: remove node5

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -42,7 +42,6 @@
   "node010": "homebrew/core",
   "node012": "homebrew/core",
   "node4-lts": "homebrew/core",
-  "node5": "homebrew/core",
   "node6-lts": "homebrew/core",
   "ppl011": "homebrew/core",
   "protobuf250": "homebrew/core",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-versions/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
- [ ] Does your submission adhere to Versions "Acceptable Formulae" [guidelines](https://github.com/Homebrew/homebrew-versions/blob/master/README.md#acceptable-formulae)?

-----

node@5 was deleted from homebrew/core.

CC @MikeMcQuaid