### PR TITLE
tap_migrations: remove elasticsearch@1.7

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -26,7 +26,6 @@
   "docker171": "homebrew/core",
   "drush5": "homebrew/php",
   "eigen32": "homebrew/core",
-  "elasticsearch17": "homebrew/core",
   "elasticsearch24": "homebrew/core",
   "erlang-r18": "homebrew/core",
   "ffmpeg28": "homebrew/core",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-versions/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
- [ ] Does your submission adhere to Versions "Acceptable Formulae" [guidelines](https://github.com/Homebrew/homebrew-versions/blob/master/README.md#acceptable-formulae)?